### PR TITLE
Fix automatic IE launch in Windows - set Chrome as default.

### DIFF
--- a/remi/server.py
+++ b/remi/server.py
@@ -35,6 +35,7 @@ import threading
 import signal
 import time
 import os.path
+import os
 import re
 from threading import Timer
 try:
@@ -646,7 +647,12 @@ class Server(object):
                 import android
                 android.webbrowser.open(base_address)
             except:
-                webbrowser.open(base_address)
+                # prevent webbrowser from opening automatically in IE on Windows
+                if os.name == 'nt':
+                    chrome_path = 'C:\Program Files (x86)\Google\Chrome\Application\chrome.exe %s'
+                    webbrowser.get(chrome_path).open(base_address)
+                else:
+                    webbrowser.open(base_address)
         self._sth = threading.Thread(target=self._sserver.serve_forever)
         self._sth.daemon = True
         self._sth.start()

--- a/remi/server.py
+++ b/remi/server.py
@@ -647,10 +647,9 @@ class Server(object):
                 import android
                 android.webbrowser.open(base_address)
             except:
-                # prevent webbrowser from opening automatically in IE on Windows
+                # use default browser instead of always forcing IE on Windows
                 if os.name == 'nt':
-                    chrome_path = 'C:\Program Files (x86)\Google\Chrome\Application\chrome.exe %s'
-                    webbrowser.get(chrome_path).open(base_address)
+                    webbrowser.get('windows-default').open('file://' + os.path.realpath(base_address))
                 else:
                     webbrowser.open(base_address)
         self._sth = threading.Thread(target=self._sserver.serve_forever)


### PR DESCRIPTION
This prevents an automatic IE launch in Windows (which happens even when IE is not the default browser) by setting the browser to Chrome for Windows users.