### PR TITLE
Removing the + on the file permission as we are only reading the file

### DIFF
--- a/remi/server.py
+++ b/remi/server.py
@@ -571,7 +571,7 @@ ws.onerror = function(evt){
             if self.server.enable_file_cache:
                 self.send_header('Cache-Control', 'public, max-age=86400')
             self.end_headers()
-            with open(filename, 'r+b') as f:
+            with open(filename, 'rb') as f:
                 content = f.read()
                 self.wfile.write(content)
         elif attr_call:


### PR DESCRIPTION
This solves the issue I opened: https://github.com/dddomodossola/remi/issues/37

I tested it installing it with pip doing:

    sudo pip install --ignore-installed https://github.com/awesomebytes/remi/archive/no_writting_permission.zip

And now works as expected