### PR TITLE
Keeping the connection alive if there is an expected timeout

### DIFF
--- a/remi/server.py
+++ b/remi/server.py
@@ -22,6 +22,7 @@ try:
     import socketserver
 except:
     import SocketServer as socketserver
+import socket
 import mimetypes
 import webbrowser
 import struct

--- a/remi/server.py
+++ b/remi/server.py
@@ -163,11 +163,11 @@ class WebSocketsHandler(socketserver.StreamRequestHandler):
 
     def read_next_message(self):
         log.debug('ws read_next_message')
-        start_read_time = time()
+        start_read_time = time.time()
         try:
             length = self.rfile.read(2)
         except socket.timeout:
-            end_read_time = time()
+            end_read_time = time.time()
             TCP_FIN_TIMEOUT_TIME = 60.0 # In linux, take from /proc/sys/net/ipv4/tcp_fin_timeout
             # Some Windows is 240s, linux 60s according to this link
             # http://www.outsystems.com/forums/discussion/6956/how-to-tune-the-tcp-ip-stack-for-high-volume-of-web-requests/


### PR DESCRIPTION
After doing some research on what can timeout our socket, I found out that there is a normal read timeout, which is based on the SO configuration.

This link:

http://www.outsystems.com/forums/discussion/6956/how-to-tune-the-tcp-ip-stack-for-high-volume-of-web-requests/

Shows the timeouts of a couple of Windows and Linux Red Hat, which you can check in your linux OS (sorry, I haven't looked for Windows where it is) doing:

    > cat /proc/sys/net/ipv4/tcp_fin_timeout
    60

I've left a server running for a full day and the screen slowly went full of my debug print "read_next_message did a timeout, probably because of tcp_fin_timeout configuration", one every minute. And the web-gui is still completely responsive after lots of them. But... this does not appear always. I've tried to debug what is going on with the chrome Network thing of the Developer tools.

Note: For running the server the address was: 0.0.0.0 and the browser was connected to the LAN IP 192.168.1.X that I had.

If there is a timeout in less than that provided time, it should mean something went wrong. That's all I got... but I really can't figure out how to reproduce this properly.
