### PR TITLE
Update gui.py:repr() to handle number types

### DIFF
--- a/remi/gui.py
+++ b/remi/gui.py
@@ -87,6 +87,10 @@ class Tag(object):
                 innerHTML = innerHTML + s
             elif isinstance(s, type(u'')):
                 innerHTML = innerHTML + s.encode('utf-8')
+            elif isinstance(s, float):
+                innerHTML = innerHTML + '{}'.format(s)
+            elif isinstance(s, int):
+                innerHTML = innerHTML + '{}'.format(s)
             elif include_children:
                 innerHTML = innerHTML + s.repr(client)
 


### PR DESCRIPTION
When a gui.TextInput has just a number entered into it, an int or float is set as the child. Subsequently, repr() fails on that element. This change does the simplest thing possible, but I'm ignorant of any impact to the overall design vision.