### PR TITLE
Add ability to set a placeholder hint for TextInput widgets

### DIFF
--- a/remi/gui.py
+++ b/remi/gui.py
@@ -871,11 +871,12 @@ class TextInput(Widget):
     EVENT_ONENTER = 'onenter'
 
     @decorate_constructor_parameter_types([bool])
-    def __init__(self, single_line=True, **kwargs):
+    def __init__(self, single_line=True, hint='', **kwargs):
         """
         Args:
             single_line (bool): Determines if the TextInput have to be single_line. A multiline TextInput have a gripper
                                 that allows the resize.
+            hint (str): Sets a hint using the html placeholder attribute.
             kwargs: See Widget.__init__()
         """
         super(TextInput, self).__init__(**kwargs)
@@ -890,6 +891,8 @@ class TextInput(Widget):
         if single_line:
             self.style['resize'] = 'none'
             self.attributes['rows'] = '1'
+        if hint:
+            self.attributes['placeholder'] = hint
 
     def set_text(self, text):
         """Sets the text content.


### PR DESCRIPTION
It's a tiny commit, but it fixes an issue I've been having with TextInput widgets. Currently, the example recommends using the set_text() method to prepopulate the text field, but this means that a user must first delete the set text before they can add their own. This PR allows the setting of a 'hint' during TextInput creation through the use of the HTML5 placeholder attribute.

The hint appears as so:
![hint](https://cloud.githubusercontent.com/assets/1031518/15264171/f655a73e-19b3-11e6-9794-a6b092f6da18.png)

As soon as the user begins to enter text, the hint disappears automatically. Deleting all text redisplays the hint.