### PR TITLE
Python 3 support added for TabBox

### DIFF
--- a/remi/gui.py
+++ b/remi/gui.py
@@ -850,7 +850,7 @@ class VBox(HBox):
         super(VBox, self).__init__(**kwargs)
         self.style['flex-direction'] = 'column'
 
-
+         
 class TabBox(Widget):
 
     # create a structure like the following
@@ -891,7 +891,6 @@ class TabBox(Widget):
         for a, li, holder in self._tabs.values():
             a.remove_class('active')
             holder.attributes['style'] = 'padding:15px;display:none'
-               
         # add it on the current one
         a, li, holder = self._tabs[tab_identifier]
         a.add_class('active')
@@ -2593,4 +2592,4 @@ class SvgText(SvgShape):
     def set_text(self, text):
         self.add_child('text', text)
 
-    
+ 

--- a/remi/gui.py
+++ b/remi/gui.py
@@ -880,29 +880,17 @@ class TabBox(Widget):
 
         # maps tabs to their corresponding tab header
         self._tabs = {}
-         
-        # get python version
-        self.python_version = sys.version_info[0]
 
     def _fix_tab_widths(self):
         tab_w = 100.0 / len(self._tabs)
-        if self.python_version == 2:
-            for a, li, holder in self._tabs.itervalues():
-                li.attributes['style'] = "float:left;width:%.1f%%" % tab_w
-        else:
-            for a, li, holder in self._tabs.values():
-                li.attributes['style'] = "float:left;width:%.1f%%" % tab_w
+        for a, li, holder in self._tabs.values():
+            li.attributes['style'] = "float:left;width:%.1f%%" % tab_w
 
     def _on_tab_pressed(self, tab_identifier):
         # remove active on all tabs, and hide their contents
-        if self.python_version == 2:
-            for a, li, holder in self._tabs.itervalues():
-                a.remove_class('active')
-                holder.attributes['style'] = 'padding:15px;display:none'
-        else:
-            for a, li, holder in self._tabs.values():
-                a.remove_class('active')
-                holder.attributes['style'] = 'padding:15px;display:none'
+        for a, li, holder in self._tabs.values():
+            a.remove_class('active')
+            holder.attributes['style'] = 'padding:15px;display:none'
                
         # add it on the current one
         a, li, holder = self._tabs[tab_identifier]

--- a/remi/gui.py
+++ b/remi/gui.py
@@ -880,18 +880,30 @@ class TabBox(Widget):
 
         # maps tabs to their corresponding tab header
         self._tabs = {}
+         
+        # get python version
+        self.python_version = sys.version_info[0]
 
     def _fix_tab_widths(self):
         tab_w = 100.0 / len(self._tabs)
-        for a, li, holder in self._tabs.itervalues():
-            li.attributes['style'] = "float:left;width:%.1f%%" % tab_w
+        if self.python_version == 2:
+            for a, li, holder in self._tabs.itervalues():
+                li.attributes['style'] = "float:left;width:%.1f%%" % tab_w
+        else:
+            for a, li, holder in self._tabs.values():
+                li.attributes['style'] = "float:left;width:%.1f%%" % tab_w
 
     def _on_tab_pressed(self, tab_identifier):
         # remove active on all tabs, and hide their contents
-        for a, li, holder in self._tabs.itervalues():
-            a.remove_class('active')
-            holder.attributes['style'] = 'padding:15px;display:none'
-
+        if self.python_version == 2:
+            for a, li, holder in self._tabs.itervalues():
+                a.remove_class('active')
+                holder.attributes['style'] = 'padding:15px;display:none'
+        else:
+            for a, li, holder in self._tabs.values():
+                a.remove_class('active')
+                holder.attributes['style'] = 'padding:15px;display:none'
+               
         # add it on the current one
         a, li, holder = self._tabs[tab_identifier]
         a.add_class('active')


### PR DESCRIPTION
The tabbox demo does not function for python3 due to calls .itervalues. The TabBox class was modified to set a variable for the current version of python in use and then call either the python 2 or python 3 version to correctly iterate based on the current version in use.