### PR TITLE
Logging: improves setting debug level.

### DIFF
--- a/remi/server.py
+++ b/remi/server.py
@@ -1017,6 +1017,8 @@ def start(mainGuiClass, **kwargs):
     standalone = kwargs.pop('standalone', False)
     logging.basicConfig(level=logging.DEBUG if debug else logging.INFO,
                         format='%(name)-16s %(levelname)-8s %(message)s')
+    logging.getLogger('remi').setLevel(
+            level=logging.DEBUG if debug else logging.INFO)
     if standalone:
         s = StandaloneServer(mainGuiClass, start=True, **kwargs)
     else:


### PR DESCRIPTION
If the root logger is already configured, for example
because some imported module of the App already called basicConfig()
and setLevel(), the debug option to start() has no effect.
Thus setting the loglevel explicitely for the remi logger.