### PR TITLE
Rendering: improves repr of Python types

### DIFF
--- a/remi/gui.py
+++ b/remi/gui.py
@@ -207,7 +207,11 @@ class Tag(object):
             elif isinstance(s, type(u'')):
                 innerHTML = innerHTML + s.encode('utf-8')
             else:
-                innerHTML = innerHTML + s.repr(client, local_changed_widgets)
+                try:
+                    innerHTML = innerHTML + s.repr(client,
+                                                   local_changed_widgets)
+                except:
+                    innerHTML = innerHTML + repr(s)
 
         if self._ischanged() or ( len(local_changed_widgets) > 0 ):
             self.attributes['style'] = jsonize(self.style)

--- a/remi/server.py
+++ b/remi/server.py
@@ -1017,6 +1017,8 @@ def start(mainGuiClass, **kwargs):
     standalone = kwargs.pop('standalone', False)
     logging.basicConfig(level=logging.DEBUG if debug else logging.INFO,
                         format='%(name)-16s %(levelname)-8s %(message)s')
+    logging.getLogger('remi').setLevel(
+            level=logging.DEBUG if debug else logging.INFO)
     if standalone:
         s = StandaloneServer(mainGuiClass, start=True, **kwargs)
     else:


### PR DESCRIPTION
Makes it more robust against trying to render regular Python types.
For example if you fill in a table by matrix that has integers in it.