### PR TITLE
Rendering: improves repr of Python types

### DIFF
--- a/remi/gui.py
+++ b/remi/gui.py
@@ -210,7 +210,7 @@ class Tag(object):
                 try:
                     innerHTML = innerHTML + s.repr(client,
                                                    local_changed_widgets)
-                except:
+                except AttributeError:
                     innerHTML = innerHTML + repr(s)
 
         if self._ischanged() or ( len(local_changed_widgets) > 0 ):


### PR DESCRIPTION
Adds robustness, only catching AttributeError as test
if the repr() method exits. (Thanks to @nzjrs for noticing.)
