### PR TITLE
Style in constructors

### DIFF
--- a/examples/layout_app.py
+++ b/examples/layout_app.py
@@ -14,13 +14,8 @@ class untitled(App):
         pass
     
     def main(self):
-        mainContainer = Widget(width=706, height=445, margin='0px auto')
-        mainContainer.style["position"] = "relative"
-        subContainer = HBox(width=630, height=277)
-        subContainer.style['position'] = "absolute"
-        subContainer.style['left'] = "40px"
-        subContainer.style['top'] = "150px"
-        subContainer.style['background-color'] = "#b6b6b6"
+        mainContainer = Widget(width=706, height=445, margin='0px auto', style="position: relative")
+        subContainer = HBox(width=630, height=277, style='position: absolute; left: 40px; top: 150px; background-color: #b6b6b6')
         vbox = VBox(width=300, height=250)
         bt1 = Button('bt1', width=100, height=30)
         vbox.append(bt1,'bt1')
@@ -30,52 +25,29 @@ class untitled(App):
         vbox.append(bt2,'bt2')
         subContainer.append(vbox,'vbox')
         hbox = HBox(width=300, height=250)
-        lbl1 = Label('lbl1', width=50, height=50)
-        lbl1.style['background-color'] = "#ffb509"
+        lbl1 = Label('lbl1', width=50, height=50, style='background-color: #ffb509')
         hbox.append(lbl1,'lbl1')
-        lbl2 = Label('lbl2', width=50, height=50)
-        lbl2.style['background-color'] = "#40ff2b"
+        lbl2 = Label('lbl2', width=50, height=50, style='background-color: #40ff2b')
         hbox.append(lbl2,'lbl2')
-        lbl3 = Label('lbl3', width=50, height=50)
-        lbl3.style['background-color'] = "#e706ff"
+        lbl3 = Label('lbl3', width=50, height=50, style='background-color: #e706ff')
         hbox.append(lbl3,'lbl3')
         subContainer.append(hbox,'hbox')
         mainContainer.append(subContainer,'subContainer')
-        comboJustifyContent = gui.DropDown.new_from_list(('flex-start','flex-end','center','space-between','space-around'))
-        comboJustifyContent.style['left'] = "160px"
-        comboJustifyContent.style['position'] = "absolute"
-        comboJustifyContent.style['top'] = "60px"
-        comboJustifyContent.style['width'] = "148px"
-        comboJustifyContent.style['height'] = "30px"
+        comboJustifyContent = gui.DropDown.new_from_list(('flex-start','flex-end','center','space-between','space-around'),
+                                    style='left: 160px; position: absolute; top: 60px; width: 148px; height: 30px')
         mainContainer.append(comboJustifyContent,'comboJustifyContent')
-        lblJustifyContent = Label('justify-content')
-        lblJustifyContent.style['left'] = "40px"
-        lblJustifyContent.style['position'] = "absolute"
-        lblJustifyContent.style['top'] = "60px"
-        lblJustifyContent.style['width'] = "100px"
-        lblJustifyContent.style['height'] = "30px"
+        lblJustifyContent = Label('justify-content', style='left: 40px; position: absolute; top: 60px; width: 100px; height: 30px')
         mainContainer.append(lblJustifyContent,'lblJustifyContent')
-        comboAlignItems = gui.DropDown.new_from_list(('stretch','center','flex-start','flex-end','baseline'))
-        comboAlignItems.style['left'] = "160px"
-        comboAlignItems.style['position'] = "absolute"
-        comboAlignItems.style['top'] = "100px"
-        comboAlignItems.style['width'] = "152px"
-        comboAlignItems.style['height'] = "30px"
+        comboAlignItems = gui.DropDown.new_from_list(('stretch','center','flex-start','flex-end','baseline'),
+                                    style='left:160px; position:absolute; top:100px; width:152px; height: 30px')
         mainContainer.append(comboAlignItems,'comboAlignItems')
-        lblAlignItems = Label('align-items')
-        lblAlignItems.style['left'] = "40px"
-        lblAlignItems.style['position'] = "absolute"
-        lblAlignItems.style['top'] = "100px"
-        lblAlignItems.style['width'] = "100px"
-        lblAlignItems.style['height'] = "30px"
+        lblAlignItems = Label('align-items', style='left:40px; position:absolute; top:100px; width:100px; height:30px')
         mainContainer.append(lblAlignItems,'lblAlignItems')
         mainContainer.children['comboJustifyContent'].set_on_change_listener(self.onchange_comboJustifyContent,vbox,hbox)
         mainContainer.children['comboAlignItems'].set_on_change_listener(self.onchange_comboAlignItems,vbox,hbox)
 
-        lblTitle = gui.Label("The following example shows the two main layout style properties for the VBox and HBox containers. Change the value of the two combo boxes.")
-        lblTitle.style['position'] = "absolute"
-        lblTitle.style['left'] = "0px"
-        lblTitle.style['top'] = "0px"
+        lblTitle = gui.Label("The following example shows the two main layout style properties for the VBox and HBox containers. Change the value of the two combo boxes.",
+                                    style='position:absolute; left:0px; top:0px')
         mainContainer.append(lblTitle)
 
         self.mainContainer = mainContainer

--- a/examples/widgets_overview_app.py
+++ b/examples/widgets_overview_app.py
@@ -22,18 +22,12 @@ class MyApp(App):
         super(MyApp, self).__init__(*args)
 
     def main(self):
-        verticalContainer = gui.Widget(width=540, margin='0px auto') #the margin 0px auto centers the main container
-        verticalContainer.style['display'] = 'block'
-        verticalContainer.style['overflow'] = 'hidden'
+        # the margin 0px auto centers the main container
+        verticalContainer = gui.Widget(width=540, margin='0px auto', style='display: block; overflow: hidden')
 
-        horizontalContainer = gui.Widget(width='100%', layout_orientation=gui.Widget.LAYOUT_HORIZONTAL, margin='0px')
-        horizontalContainer.style['display'] = 'block'
-        horizontalContainer.style['overflow'] = 'auto'
+        horizontalContainer = gui.Widget(width='100%', layout_orientation=gui.Widget.LAYOUT_HORIZONTAL, margin='0px', style='display: block; overflow: auto')
         
-        subContainerLeft = gui.Widget(width=320)
-        subContainerLeft.style['display'] = 'block'
-        subContainerLeft.style['overflow'] = 'auto'
-        subContainerLeft.style['text-align'] = 'center'
+        subContainerLeft = gui.Widget(width=320, style='display: block; overflow: auto; text-align: center')
         self.img = gui.Image('/res/logo.png', width=100, height=100, margin='10px')
         self.img.set_on_click_listener(self.on_img_clicked)
 
@@ -45,11 +39,7 @@ class MyApp(App):
                                    ('105', 'Maria', 'Papadopoulos')], width=300, height=200, margin='10px')
 
         # the arguments are	width - height - layoutOrientationOrizontal
-        subContainerRight = gui.Widget()
-        subContainerRight.style['width'] = '220px'
-        subContainerRight.style['display'] = 'block'
-        subContainerRight.style['overflow'] = 'auto'
-        subContainerRight.style['text-align'] = 'center'
+        subContainerRight = gui.Widget(style='width: 220px; display: block; overflow: auto; text-align: center')
         self.count = 0
         self.counter = gui.Label('', width=200, height=30, margin='10px')
 

--- a/examples/widgets_overview_app.py
+++ b/examples/widgets_overview_app.py
@@ -23,11 +23,11 @@ class MyApp(App):
 
     def main(self):
         # the margin 0px auto centers the main container
-        verticalContainer = gui.Widget(width=540, margin='0px auto', style='display: block; overflow: hidden')
+        verticalContainer = gui.Widget(width=540, margin='0px auto', style={'display': 'block', 'overflow': 'hidden'})
 
-        horizontalContainer = gui.Widget(width='100%', layout_orientation=gui.Widget.LAYOUT_HORIZONTAL, margin='0px', style='display: block; overflow: auto')
+        horizontalContainer = gui.Widget(width='100%', layout_orientation=gui.Widget.LAYOUT_HORIZONTAL, margin='0px', style={'display': 'block', 'overflow': 'auto'})
         
-        subContainerLeft = gui.Widget(width=320, style='display: block; overflow: auto; text-align: center')
+        subContainerLeft = gui.Widget(width=320, style={'display': 'block', 'overflow': 'auto', 'text-align': 'center'})
         self.img = gui.Image('/res/logo.png', width=100, height=100, margin='10px')
         self.img.set_on_click_listener(self.on_img_clicked)
 
@@ -39,7 +39,7 @@ class MyApp(App):
                                    ('105', 'Maria', 'Papadopoulos')], width=300, height=200, margin='10px')
 
         # the arguments are	width - height - layoutOrientationOrizontal
-        subContainerRight = gui.Widget(style='width: 220px; display: block; overflow: auto; text-align: center')
+        subContainerRight = gui.Widget(style={'width': '220px', 'display': 'block', 'overflow': 'auto', 'text-align': 'center'})
         self.count = 0
         self.counter = gui.Label('', width=200, height=30, margin='10px')
 

--- a/remi/gui.py
+++ b/remi/gui.py
@@ -72,15 +72,18 @@ def decorate_constructor_parameter_types(type_list):
 
 
 def allow_style(fn):
+    @functools.wraps(fn)
     def decorated(self, *args, **kwargs):
         style = kwargs.pop('style', None)
         fn(self, *args, **kwargs)
         if style is not None:
-            for s in style.split(';'):
-                k, v = s.split(':', 1)
-                self.style[k.strip()] = v.strip()
+            try:
+                self.style.update(style)
+            except ValueError:
+                for s in style.split(';'):
+                    k, v = s.split(':', 1)
+                    self.style[k.strip()] = v.strip()
     return decorated
-
 
 
 def to_pix(x):

--- a/remi/gui.py
+++ b/remi/gui.py
@@ -71,6 +71,18 @@ def decorate_constructor_parameter_types(type_list):
     return add_annotation
 
 
+def allow_style(fn):
+    def decorated(self, *args, **kwargs):
+        style = kwargs.pop('style', None)
+        fn(self, *args, **kwargs)
+        if style is not None:
+            for s in style.split(';'):
+                k, v = s.split(':', 1)
+                self.style[k.strip()] = v.strip()
+    return decorated
+
+
+
 def to_pix(x):
     return str(x) + 'px'
 
@@ -346,6 +358,7 @@ class Widget(Tag):
     EVENT_ONCONTEXTMENU = "oncontextmenu"
     EVENT_ONUPDATE = 'onupdate'
 
+    @allow_style
     @decorate_constructor_parameter_types([])
     def __init__(self, **kwargs):
         """
@@ -810,6 +823,7 @@ class HBox(Widget):
     Note: If you would absolute positioning, use the Widget container instead.
     """
 
+    @allow_style
     @decorate_constructor_parameter_types([])
     def __init__(self, **kwargs):
         super(HBox, self).__init__(**kwargs)
@@ -873,6 +887,7 @@ class VBox(HBox):
     Note: If you would absolute positioning, use the Widget container instead.
     """
 
+    @allow_style
     @decorate_constructor_parameter_types([])
     def __init__(self, **kwargs):
         super(VBox, self).__init__(**kwargs)
@@ -894,6 +909,7 @@ class TabBox(Widget):
     # <section id="first-tab-group">
     #   <div id="tab1">
 
+    @allow_style
     def __init__(self, **kwargs):
         super(TabBox, self).__init__(**kwargs)
 
@@ -1012,6 +1028,7 @@ class Button(Widget, _MixinTextualWidget):
     """The Button widget. Have to be used in conjunction with its event onclick.
     Use Widget.set_on_click_listener in order to register the listener.
     """
+    @allow_style
     @decorate_constructor_parameter_types([str])
     def __init__(self, text='', **kwargs):
         """
@@ -1032,6 +1049,7 @@ class TextInput(Widget, _MixinTextualWidget):
 
     EVENT_ONENTER = 'onenter'
 
+    @allow_style
     @decorate_constructor_parameter_types([bool, str])
     def __init__(self, single_line=True, hint='', **kwargs):
         """
@@ -1170,6 +1188,8 @@ class Label(Widget, _MixinTextualWidget):
     """Non editable text label widget. Set its content by means of set_text function, and retrieve its content with the
     function get_text.
     """
+
+    @allow_style
     @decorate_constructor_parameter_types([str])
     def __init__(self, text, **kwargs):
         """
@@ -1195,6 +1215,7 @@ class GenericDialog(Widget):
     EVENT_ONCONFIRM = 'confirm_dialog'
     EVENT_ONCANCEL = 'cancel_dialog'
 
+    @allow_style
     @decorate_constructor_parameter_types([str, str])
     def __init__(self, title='', message='', **kwargs):
         """
@@ -1354,6 +1375,7 @@ class InputDialog(GenericDialog):
 
     EVENT_ONCONFIRMVALUE = 'confirm_value'
 
+    @allow_style
     @decorate_constructor_parameter_types([str, str, str])
     def __init__(self, title='Title', message='Message', initial_value='', **kwargs):
         """
@@ -1430,6 +1452,7 @@ class ListView(Widget, _SyncableValuesMixin):
 
     EVENT_ONSELECTION = 'onselection'
 
+    @allow_style
     @decorate_constructor_parameter_types([bool])
     def __init__(self, selectable=True, **kwargs):
         """
@@ -1565,6 +1588,7 @@ class ListItem(Widget, _MixinTextualWidget):
     the ListView.
     """
 
+    @allow_style
     @decorate_constructor_parameter_types([str])
     def __init__(self, text, **kwargs):
         """
@@ -1595,6 +1619,7 @@ class DropDown(Widget, _SyncableValuesMixin):
     by means of the function DropDown.set_on_change_listener.
     """
 
+    @allow_style
     @decorate_constructor_parameter_types([])
     def __init__(self, **kwargs):
         """
@@ -1709,6 +1734,7 @@ class DropDown(Widget, _SyncableValuesMixin):
 class DropDownItem(Widget, _MixinTextualWidget):
     """item widget for the DropDown"""
 
+    @allow_style
     @decorate_constructor_parameter_types([str])
     def __init__(self, text, **kwargs):
         """
@@ -1730,6 +1756,7 @@ class DropDownItem(Widget, _MixinTextualWidget):
 class Image(Widget):
     """image widget."""
 
+    @allow_style
     @decorate_constructor_parameter_types([str])
     def __init__(self, filename, **kwargs):
         """
@@ -1747,6 +1774,7 @@ class Table(Widget):
     table widget - it will contains TableRow
     """
 
+    @allow_style
     @decorate_constructor_parameter_types([])
     def __init__(self, **kwargs):
         """
@@ -1816,6 +1844,7 @@ class TableRow(Widget):
     row widget for the Table - it will contains TableItem
     """
 
+    @allow_style
     @decorate_constructor_parameter_types([])
     def __init__(self, **kwargs):
         """
@@ -1830,6 +1859,7 @@ class TableRow(Widget):
 class TableItem(Widget):
     """item widget for the TableRow."""
 
+    @allow_style
     @decorate_constructor_parameter_types([str])
     def __init__(self, text='', **kwargs):
         """
@@ -1846,6 +1876,7 @@ class TableItem(Widget):
 class TableTitle(Widget):
     """title widget for the table."""
 
+    @allow_style
     @decorate_constructor_parameter_types([str])
     def __init__(self, title='', **kwargs):
         """
@@ -1860,6 +1891,7 @@ class TableTitle(Widget):
 
 
 class Input(Widget):
+    @allow_style
     @decorate_constructor_parameter_types([str, str])
     def __init__(self, input_type='', default_value='', **kwargs):
         """
@@ -1911,6 +1943,7 @@ class Input(Widget):
 
 
 class CheckBoxLabel(Widget):
+    @allow_style
     @decorate_constructor_parameter_types([str, bool, str])
     def __init__(self, label='', checked=False, user_data='', **kwargs):
         """
@@ -1943,6 +1976,7 @@ class CheckBoxLabel(Widget):
 class CheckBox(Input):
     """check box widget useful as numeric input field implements the onchange event."""
 
+    @allow_style
     @decorate_constructor_parameter_types([bool, str])
     def __init__(self, checked=False, user_data='', **kwargs):
         """
@@ -1982,6 +2016,7 @@ class SpinBox(Input):
     """
 
     # noinspection PyShadowingBuiltins
+    @allow_style
     @decorate_constructor_parameter_types([str, int, int, int])
     def __init__(self, default_value='100', min=100, max=5000, step=1, allow_editing=True, **kwargs):
         """
@@ -2012,6 +2047,7 @@ class Slider(Input):
     EVENT_ONINPUT = 'oninput'
 
     # noinspection PyShadowingBuiltins
+    @allow_style
     @decorate_constructor_parameter_types([str, int, int, int])
     def __init__(self, default_value='', min=0, max=10000, step=1, **kwargs):
         """
@@ -2043,6 +2079,7 @@ class Slider(Input):
 
 
 class ColorPicker(Input):
+    @allow_style
     @decorate_constructor_parameter_types([str])
     def __init__(self, default_value='#995500', **kwargs):
         """
@@ -2054,6 +2091,7 @@ class ColorPicker(Input):
 
 
 class Date(Input):
+    @allow_style
     @decorate_constructor_parameter_types([str])
     def __init__(self, default_value='2015-04-13', **kwargs):
         """
@@ -2069,6 +2107,7 @@ class GenericObject(Widget):
     GenericObject widget - allows to show embedded object like pdf,swf..
     """
 
+    @allow_style
     @decorate_constructor_parameter_types([str])
     def __init__(self, filename, **kwargs):
         """
@@ -2084,6 +2123,7 @@ class GenericObject(Widget):
 class FileFolderNavigator(Widget):
     """FileFolderNavigator widget."""
 
+    @allow_style
     @decorate_constructor_parameter_types([bool, str, bool, bool])
     def __init__(self, multiple_selection, selection_folder, allow_file_selection, allow_folder_selection, **kwargs):
         super(FileFolderNavigator, self).__init__(**kwargs)
@@ -2241,6 +2281,7 @@ class FileFolderItem(Widget):
 
     EVENT_ONSELECTION = 'onselection'
 
+    @allow_style
     @decorate_constructor_parameter_types([str, bool])
     def __init__(self, text, is_folder=False, **kwargs):
         super(FileFolderItem, self).__init__(**kwargs)
@@ -2294,6 +2335,7 @@ class FileSelectionDialog(GenericDialog):
 
     EVENT_ONCONFIRMVALUE = 'confirm_value'
 
+    @allow_style
     @decorate_constructor_parameter_types([str, str, bool, str, bool, bool])
     def __init__(self, title='File dialog', message='Select files and folders',
                  multiple_selection=True, selection_folder='.',
@@ -2326,6 +2368,7 @@ class FileSelectionDialog(GenericDialog):
 
 
 class MenuBar(Widget):
+    @allow_style
     @decorate_constructor_parameter_types([])
     def __init__(self, **kwargs):
         """
@@ -2340,6 +2383,7 @@ class MenuBar(Widget):
 class Menu(Widget):
     """Menu widget can contain MenuItem."""
 
+    @allow_style
     @decorate_constructor_parameter_types([])
     def __init__(self, **kwargs):
         """
@@ -2354,6 +2398,7 @@ class Menu(Widget):
 class MenuItem(Widget, _MixinTextualWidget):
     """MenuItem widget can contain other MenuItem."""
 
+    @allow_style
     @decorate_constructor_parameter_types([str])
     def __init__(self, text, **kwargs):
         """
@@ -2377,6 +2422,7 @@ class MenuItem(Widget, _MixinTextualWidget):
 class TreeView(Widget):
     """TreeView widget can contain TreeItem."""
 
+    @allow_style
     @decorate_constructor_parameter_types([])
     def __init__(self, **kwargs):
         """
@@ -2390,6 +2436,7 @@ class TreeView(Widget):
 class TreeItem(Widget, _MixinTextualWidget):
     """TreeItem widget can contain other TreeItem."""
 
+    @allow_style
     @decorate_constructor_parameter_types([str])
     def __init__(self, text, **kwargs):
         """
@@ -2431,6 +2478,7 @@ class FileUploader(Widget):
         implements the onsuccess and onfailed events.
     """
 
+    @allow_style
     @decorate_constructor_parameter_types([str, bool])
     def __init__(self, savepath='./', multiple_selection_allowed=False, **kwargs):
         super(FileUploader, self).__init__(**kwargs)
@@ -2513,6 +2561,7 @@ class FileDownloader(Widget, _MixinTextualWidget):
 
 
 class Link(Widget, _MixinTextualWidget):
+    @allow_style
     @decorate_constructor_parameter_types([str, str, bool])
     def __init__(self, url, text, open_new_window=True, **kwargs):
         super(Link, self).__init__(**kwargs)
@@ -2530,6 +2579,7 @@ class VideoPlayer(Widget):
     # some constants for the events
     EVENT_ONENDED = 'onended'
 
+    @allow_style
     @decorate_constructor_parameter_types([str, str, bool, bool])
     def __init__(self, video, poster=None, autoplay=False, loop=False, **kwargs):
         super(VideoPlayer, self).__init__(**kwargs)
@@ -2578,6 +2628,7 @@ class VideoPlayer(Widget):
 class Svg(Widget):
     """svg widget - is a container for graphic widgets such as SvgCircle, SvgLine and so on."""
 
+    @allow_style
     @decorate_constructor_parameter_types([int, int])
     def __init__(self, width, height, **kwargs):
         """
@@ -2608,6 +2659,7 @@ class Svg(Widget):
 class SvgShape(Widget):
     """svg shape generic widget. Consists of a position, a fill color and a stroke."""
 
+    @allow_style
     @decorate_constructor_parameter_types([int, int, int])
     def __init__(self, x, y, **kwargs):
         """
@@ -2652,6 +2704,7 @@ class SvgShape(Widget):
 class SvgRectangle(SvgShape):
     """svg rectangle - a rectangle represented filled and with a stroke."""
 
+    @allow_style
     @decorate_constructor_parameter_types([int, int, int])
     def __init__(self, x, y, w, h, **kwargs):
         """
@@ -2680,6 +2733,7 @@ class SvgRectangle(SvgShape):
 class SvgCircle(SvgShape):
     """svg circle - a circle represented filled and with a stroke."""
 
+    @allow_style
     @decorate_constructor_parameter_types([int, int, int])
     def __init__(self, x, y, radius, **kwargs):
         """
@@ -2713,6 +2767,7 @@ class SvgCircle(SvgShape):
 
 
 class SvgLine(Widget):
+    @allow_style
     @decorate_constructor_parameter_types([int, int, int, int])
     def __init__(self, x1, y1, x2, y2, **kwargs):
         super(SvgLine, self).__init__(**kwargs)
@@ -2738,6 +2793,7 @@ class SvgLine(Widget):
 
 
 class SvgPolyline(Widget):
+    @allow_style
     @decorate_constructor_parameter_types([int])
     def __init__(self, _maxlen=None, **kwargs):
         super(SvgPolyline, self).__init__(**kwargs)
@@ -2765,6 +2821,7 @@ class SvgPolyline(Widget):
 
 
 class SvgText(SvgShape, _MixinTextualWidget):
+    @allow_style
     @decorate_constructor_parameter_types([int, int, str])
     def __init__(self, x, y, text, **kwargs):
         super(SvgText, self).__init__(x, y, **kwargs)


### PR DESCRIPTION
    Allow to set style css specs in Widget constructors.

    It is implemented as decorator for __init__().
    Rationale behind this choice is some widget constructors set style
    parameters; If setting is done in ancestor constructor it will be
    (in some cases) overridden. This will (probably) become more and
    more the case as Remi evolves and "default" styling will incerase.
    Assumption is widgets can (perhaps "should") suggest some styling,
    but explicit user choices should take precedence.

    The examples widgets_overview_app.py and layout_app.py were
    modified to use the new capability.

Second attempt.
This time patch is against plain "master".
I also did some more testing.
I will delete the old pull request.