### PR TITLE
Use os.path.join for saved file path building in FileUploader

### DIFF
--- a/remi/gui.py
+++ b/remi/gui.py
@@ -2477,7 +2477,7 @@ class FileUploader(Widget):
         self.eventManager.register_listener(self.EVENT_ON_FAILED, callback, *userdata)
 
     def ondata(self, filedata, filename):
-        with open(self._savepath+filename, 'wb') as f:
+        with open(os.path.join(self._savepath, filename), 'wb') as f:
             f.write(filedata)
         return self.eventManager.propagate(self.EVENT_ON_DATA, (filedata, filename))
 


### PR DESCRIPTION
Hi Davide, without this change, if somebody forget to add last slash to the _savepath_ FileUploader's constructor parameter, then files will be uploaded not to the _savepath_ folder, but one level higher and with strange names like MyFolderuploaded_filename.ext