### PR TITLE
cgi.escape is deprecated in python 3.4

### DIFF
--- a/remi/gui.py
+++ b/remi/gui.py
@@ -19,8 +19,12 @@ import functools
 import threading
 import collections
 import inspect
-import cgi
-escape = cgi.escape
+try:
+    import html
+    escape = html.escape
+except ImportError:
+    import cgi
+    escape = cgi.escape
 import mimetypes
 import base64
 try:


### PR DESCRIPTION
While setting up the unit test for the Label widget, this bug was found for python 3.4 +:

    DeprecationWarning: cgi.escape is deprecated, use html.escape instead

A possible fix is to conditionally import escape like unescape.