### PR TITLE
Fix Travis badge url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/Bethany-1/remi.svg?branch=master)](https://travis-ci.com/Bethany-1/remi)
+[![Build Status](https://travis-ci.com/dddomodossola/remi.svg?branch=master)](https://travis-ci.com/dddomodossola/remi)
 
 <p align="center">
     <img src="https://raw.githubusercontent.com/dddomodossola/remi/development/remi/res/logo.png" width="430">


### PR DESCRIPTION
The url of the testing badge was previously pointing to my fork. Now that Travis is active on the main repo, we should use the correct url.