### PR TITLE
Testability for threaded examples

### DIFF
--- a/examples/minefield_app.py
+++ b/examples/minefield_app.py
@@ -96,7 +96,8 @@ class MyApp(App):
     def display_time(self):
         self.lblTime.set_text('Play time: ' + str(self.time_count))
         self.time_count += 1
-        threading.Timer(1, self.display_time).start()
+        if not self.stop_flag:
+            threading.Timer(1, self.display_time).start()
 
     def main(self):
         # the arguments are    width - height - layoutOrientationOrizontal
@@ -153,9 +154,14 @@ class MyApp(App):
 
         self.new_game(self)
 
+        self.stop_flag = False
         self.display_time()
         # returning the root widget
         return self.main_container
+
+    def on_close(self):
+        self.stop_flag = True
+        super(MyApp, self).on_close()
 
     def coord_in_map(self, x, y, w=None, h=None):
         w = len(self.mine_matrix[0]) if w is None else w

--- a/examples/session_app.py
+++ b/examples/session_app.py
@@ -136,7 +136,9 @@ class LoginManager(gui.Tag, gui.EventSource):
     
     def timer_request_cookies(self):
         self.cookieInterface.request_cookies()
-        threading.Timer(self.session_timeout_seconds/10.0, self.timer_request_cookies).start()
+        self.cookie_timer = threading.Timer(self.session_timeout_seconds/10.0, self.timer_request_cookies)
+        self.cookie_timer.daemon = True
+        self.cookie_timer.start()
 
     @gui.decorate_event
     def on_session_expired(self):
@@ -158,6 +160,7 @@ class LoginManager(gui.Tag, gui.EventSource):
         if self.timeout_timer:
             self.timeout_timer.cancel()
         self.timeout_timer = threading.Timer(self.session_timeout_seconds, self.on_session_expired)
+        self.timeout_timer.daemon = True
         self.expired = False
         self.timeout_timer.start()
 

--- a/examples/svgplot_app.py
+++ b/examples/svgplot_app.py
@@ -179,6 +179,8 @@ class MyApp(App):
 
         self.wid.append(self.svgplot)
 
+        self.stop_flag = False
+
         self.count = 0
         self.add_data()
 
@@ -188,6 +190,10 @@ class MyApp(App):
 
         # returning the root widget
         return self.wid
+
+    def on_close(self):
+        self.stop_flag = True
+        super(MyApp, self).on_close()
 
     def zoom_out(self, emitter):
         scale_factor_x = 0.5
@@ -204,7 +210,8 @@ class MyApp(App):
             self.plotData3.add_coord(self.count, math.sin(self.count / 180.0 * math.pi))
             self.svgplot.render()
             self.count += 10
-            Timer(0.1, self.add_data).start()
+            if not self.stop_flag:
+                Timer(0.1, self.add_data).start()
 
 
 if __name__ == "__main__":

--- a/examples/threaded_app.py
+++ b/examples/threaded_app.py
@@ -57,6 +57,9 @@ class MyApp(App):
     def on_button_pressed(self, emitter):
         self.thread_alive_flag = False
 
+    def on_close(self):
+        self.thread_alive_flag = False
+        super(MyApp, self).on_close()
         
 if __name__ == "__main__":
     start(MyApp, debug=True, address='0.0.0.0', port=0, update_interval = 0.1)

--- a/test/test_examples_app.py
+++ b/test/test_examples_app.py
@@ -172,7 +172,6 @@ class TestMatplotlibApp(unittest.TestCase):
         html = root_widget.repr()
         assertValidHTML(html)
 
-@unittest.skip('This was not terminating cleanly')
 class TestMinefieldApp(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -328,7 +327,6 @@ class TestRootWidgetChangeApp(unittest.TestCase):
         html = root_widget.repr()
         assertValidHTML(html)
 
-@unittest.skip('This was not terminating cleanly')
 class TestSessionApp(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -367,7 +365,6 @@ class TestStandaloneApp(unittest.TestCase):
         html = root_widget.repr()
         assertValidHTML(html)
 
-@unittest.skip('This was not terminating cleanly')
 class TestSvgplotApp(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -384,6 +381,9 @@ class TestSvgplotApp(unittest.TestCase):
     def test_main(self):
         self.app = self.AppClass(MockRequest(), ('0.0.0.0', 8888), MockServer())
         root_widget = self.app.main()
+        html = root_widget.repr()
+        assertValidHTML(html)
+        time.sleep(1.0) # wait for some data to be generated
         html = root_widget.repr()
         assertValidHTML(html)
 
@@ -463,6 +463,7 @@ class TestThreadedApp(unittest.TestCase):
         html = root_widget.repr()
         assertValidHTML(html)
         time.sleep(1)
+        # click the button, which will stop the background thread so this can finish
         self.app.on_button_pressed(None)
 
 class TestWebAPIApp(unittest.TestCase):
@@ -484,7 +485,6 @@ class TestWebAPIApp(unittest.TestCase):
         html = root_widget.repr()
         assertValidHTML(html)
 
-@unittest.skip('This was not terminating cleanly')
 class TestWidgetOverviewApp(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Some example apps were difficult to test because they did not terminate their background threads.

This patch adds `on_close()` handlers or marks threads as `daemon=True` so that they do not stop their process from terminating.

Now there are no skipped unit tests.