### PR TITLE
Make Remi embeddable, object-ize its javascript

### DIFF
--- a/editor/__main__.py
+++ b/editor/__main__.py
@@ -2,7 +2,7 @@ from editor import prototypes
 from editor import editor_widgets
 try:
     from editor import Editor
-except:
+except ImportError:
     from editor.editor import Editor
 
 from remi import start

--- a/editor/editor.py
+++ b/editor/editor.py
@@ -21,7 +21,7 @@ import os  # for path handling
 try:
     import prototypes
     import editor_widgets
-except:
+except ImportError:
     from . import prototypes
     from . import editor_widgets
 
@@ -62,7 +62,7 @@ class DraggableItem(gui.EventSource):
         if self.parent:
             try:
                 self.parent.remove_child(self)
-            except:
+            except Exception:
                 pass
         if newParent == None:
             return
@@ -71,7 +71,7 @@ class DraggableItem(gui.EventSource):
 
         try:
             self.parent.append(self)
-        except:
+        except Exception:
             pass
         self.update_position()
 
@@ -1013,7 +1013,7 @@ class Editor(App):
                 if widgetTree != None:
                     self.add_widget_to_editor(widgetTree)
                 self.projectPathFilename = filelist[0]
-            except:
+            except Exception:
                 self.show_error_dialog("ERROR: Unable to load the project",
                                        "There were an error during project load: %s" % traceback.format_exc())
 

--- a/editor/editor_widgets.py
+++ b/editor/editor_widgets.py
@@ -182,7 +182,7 @@ class SignalConnection(gui.HBox):
                     connectedListenerFunction.__name__)
                 # force the connection
                 #self.on_connection(None, None)
-            except:
+            except Exception:
                 print(traceback.format_exc())
                 print(dir(eventConnectionFunc.callback))
                 self.disconnect()
@@ -609,7 +609,7 @@ class WidgetCollection(gui.Container):
     def load_additional_widgets(self):
         try:
             import widgets
-        except:
+        except Exception:
             from . import widgets
         try:
             classes = inspect.getmembers(widgets, inspect.isclass)
@@ -618,7 +618,7 @@ class WidgetCollection(gui.Container):
                     self.add_widget_to_collection(
                         classvalue, classvalue.__module__)
 
-        except:
+        except Exception:
             logging.getLogger('remi.editor').error(
                 'error loading external widgets', exc_info=True)
 

--- a/editor/widgets/__init__.py
+++ b/editor/widgets/__init__.py
@@ -21,7 +21,7 @@ def default_icon(name, view_w=2, view_h=0.6):
 
 try:
     from .toolbox_EPICS import EPICSBooleanButton, EPICSLed, EPICSValueMeterWidget, EPICSPlotPV, EPICSValueGaugeWidget
-except:
+except ImportError:
     class EPICSPlaceholder(gui.Label):
         icon = default_icon("missing EPICS")
         def __init__(self, msg="In order to use EPICS widgets install pyepics \n" + traceback.format_exc()):
@@ -31,7 +31,7 @@ except:
 try:
     from .toolbox_opencv import OpencvImRead, OpencvCrop, OpencvVideo, OpencvThreshold, OpencvSplit, OpencvCvtColor, OpencvAddWeighted, OpencvBitwiseNot, OpencvBitwiseAnd, OpencvBitwiseOr,\
                             OpencvBilateralFilter, OpencvBlurFilter, OpencvDilateFilter, OpencvErodeFilter, OpencvLaplacianFilter, OpencvCanny, OpencvFindContours, OpencvInRangeGrayscale
-except:
+except ImportError:
     class OPENCVPlaceholder(gui.Label):
         icon = default_icon("missing OPENCV")
         def __init__(self, msg="In order to use OpenCv widgets install python-opencv \n" + traceback.format_exc()):
@@ -42,7 +42,7 @@ from .toolbox_scheduling import TimerWidget
 
 try:
     from .toolbox_siemens import PLCSiemens, SiemensButton, BitStatusWidget, WordEditWidget, ByteViewWidget
-except:
+except ImportError:
     class SIEMENSPlaceholder(gui.Label):
         icon = default_icon("missing SIEMENS")
         def __init__(self, msg="In order to use Siemens widgets install python-snap7 \n" + traceback.format_exc()):

--- a/editor/widgets/toolbox_EPICS.py
+++ b/editor/widgets/toolbox_EPICS.py
@@ -24,7 +24,7 @@ class EPICSWidget(object):
         self.disconnect()
         try:
             self.epics_pv = epics.PV(self.__epics_pv_name, auto_monitor=True, callback=self.onChanges, connection_callback=self.onConnectionChange, connection_timeout=2)
-        except:
+        except Exception:
             print(traceback.format_exc())
     
     epics_pv = None     # here will be stored the PV instance
@@ -215,7 +215,7 @@ class EPICSValueMeterWidget(Progress, EPICSWidget):
 
 try:
     import pygal
-except:
+except ImportError:
     print("It is required to install pygal to use EPICSPlotPV widget")
 
 class EPICSPlotPV(gui.Svg, EPICSWidget):
@@ -257,7 +257,7 @@ class EPICSPlotPV(gui.Svg, EPICSWidget):
                     pairs.append([self.values.coordsX[i], self.values.coordsY[i]])
                 plot.add(self.epics_pv_name, pairs)
                 self.add_child("chart", plot.render())
-            except:
+            except Exception:
                 self.style['overflow'] = "visible"
                 self.add_child("chart", gui.SvgText(10,10, "Install pygal to use this widget"))
 

--- a/editor/widgets/toolbox_opencv.py
+++ b/editor/widgets/toolbox_opencv.py
@@ -127,7 +127,7 @@ class OpencvImage(gui.Image, OpencvWidget):
             if ret:
                 headers = {'Content-type': 'image/png', 'Cache-Control':'no-cache'}
                 return [png.tostring(), headers]
-        except:
+        except Exception:
             pass
             #print(traceback.format_exc())
         return None, None
@@ -240,7 +240,7 @@ class OpencvVideo(OpencvImage):
                     headers = {'Content-type': 'image/png', 'Cache-Control':'no-cache'}
                     # tostring is an alias to tobytes, which wasn't added till numpy 1.9
                     return [png.tostring(), headers]
-        except:
+        except Exception:
             print(traceback.format_exc())
         return None, None
 
@@ -495,7 +495,7 @@ class OpencvBitwiseNot(OpencvImage):
     def on_new_image_listener(self, emitter):
         try:
             self.set_image_data(cv2.bitwise_not(emitter.img))
-        except:
+        except Exception:
             print(traceback.format_exc())
 
 
@@ -512,14 +512,14 @@ class BinaryOperator(object):
         try:
             self.img1 = emitter.img
             self.process()
-        except:
+        except Exception:
             print(traceback.format_exc())
 
     def on_new_image_2_listener(self, emitter):
         try:
             self.img2 = emitter.img
             self.process()
-        except:
+        except Exception:
             print(traceback.format_exc())
 
 
@@ -664,7 +664,7 @@ class OpencvBilateralFilter(OpencvImage):
             self.image_source = emitter
             border = self.border_type[self.border] if type(self.border) == str else self.border
             self.set_image_data(cv2.bilateralFilter(emitter.img, self.diameter, self.sigma_color, self.sigma_space, borderType=border))
-        except:
+        except Exception:
             print(traceback.format_exc())
 
 
@@ -703,7 +703,7 @@ class OpencvBlurFilter(OpencvImage):
             self.image_source = emitter
             border = OpencvBilateralFilter.border_type[self.border] if type(self.border) == str else self.border
             self.set_image_data(cv2.blur(emitter.img, (self.kernel_size,self.kernel_size), borderType=border))
-        except:
+        except Exception:
             print(traceback.format_exc())
 
     def on_kernel_size_listener(self, emitter, value=None):
@@ -773,7 +773,7 @@ class OpencvDilateFilter(OpencvImage):
             kernel = cv2.getStructuringElement(_kernel_morph_shape, (self.kernel_size, self.kernel_size))
             border = OpencvBilateralFilter.border_type[self.border] if type(self.border) == str else self.border
             self.set_image_data(cv2.dilate(emitter.img, kernel, iterations=self.iterations, borderType=border))
-        except:
+        except Exception:
             print(traceback.format_exc())
 
 
@@ -791,7 +791,7 @@ class OpencvErodeFilter(OpencvDilateFilter):
             kernel = cv2.getStructuringElement(_kernel_morph_shape, (self.kernel_size, self.kernel_size))
             border = OpencvBilateralFilter.border_type[self.border] if type(self.border) == str else self.border
             self.set_image_data(cv2.erode(emitter.img, kernel, iterations=self.iterations, borderType=border))
-        except:
+        except Exception:
             print(traceback.format_exc())
 
 
@@ -820,7 +820,7 @@ class OpencvLaplacianFilter(OpencvImage):
             self.image_source = emitter
             border = OpencvBilateralFilter.border_type[self.border] if type(self.border) == str else self.border
             self.set_image_data(cv2.Laplacian(emitter.img, -1, borderType=border))
-        except:
+        except Exception:
             print(traceback.format_exc())
 
 
@@ -858,7 +858,7 @@ class OpencvCanny(OpencvImage):
         try:
             self.image_source = emitter
             self.set_image_data(cv2.Canny(emitter.img, self.threshold1, self.threshold2))
-        except:
+        except Exception:
             print(traceback.format_exc())
 
     def on_threshold1_listener(self, emitter, value=None):
@@ -1037,7 +1037,7 @@ class OpencvFindContours(OpencvImage):
                 img = cv2.drawContours(img, self.contours, i, 0, 1, cv2.LINE_AA)
             self.set_image_data(img)
             self.on_new_contours_result()
-        except:
+        except Exception:
             print(traceback.format_exc())
 
     def do_contours_result(self, callback, *userdata, **kwuserdata):
@@ -1092,5 +1092,5 @@ class OpencvInRangeGrayscale(OpencvImage):
         try:
             self.image_source = emitter
             self.set_image_data(cv2.inRange(emitter.img, self.threshold1, self.threshold2))
-        except:
+        except Exception:
             print(traceback.format_exc())

--- a/editor/widgets/toolbox_siemens.py
+++ b/editor/widgets/toolbox_siemens.py
@@ -113,7 +113,7 @@ class PLCSiemens(Image):
     def disconnect(self):
         try:
             self.snap7_client.disconnect()
-        except:
+        except Exception:
             print(traceback.format_exc())
 
     def connect(self):
@@ -123,7 +123,7 @@ class PLCSiemens(Image):
             print("connecting to ip:%s  rack:%s  slot:%s"%(self.ip_address, self.rack, self.slot))
             self.snap7_client.connect(self.ip_address, self.rack, self.slot)
             
-        except:
+        except Exception:
             print(traceback.format_exc())
 
     def _set_params(self):
@@ -196,7 +196,7 @@ class PLCSiemens(Image):
                         if hasattr(w, "update"):
                             try:
                                 w.update()
-                            except:
+                            except Exception:
                                 print(traceback.format_exc())
 
         if self.update_interval>0.0:

--- a/examples/examples_from_contributors/qr.py
+++ b/examples/examples_from_contributors/qr.py
@@ -57,7 +57,7 @@ class Camera(App):
     def process_image(self, **kwargs):
         try:
             image = Image.open(io.BytesIO(base64.b64decode(kwargs['image'])))
-        except:
+        except Exception:
             return
 
         qr_code_list = decode(image)

--- a/examples/minefield_app.py
+++ b/examples/minefield_app.py
@@ -43,7 +43,7 @@ class Cell(gui.TableItem):
             self.style['background-color'] = 'rgb(255,255,255)'
         else:
             self.style['background-color'] = 'rgb(245,245,240)'
-        self.oncontextmenu.do(self.on_right_click)
+        self.oncontextmenu.do(self.on_right_click, js_stop_propagation=True, js_prevent_default=True)
         self.onclick.do(self.check_mine)
 
     def on_right_click(self, widget):

--- a/examples/resizable_panes.py
+++ b/examples/resizable_panes.py
@@ -46,7 +46,7 @@ class ResizeHelper(gui.Widget, gui.EventSource):
         if self.parent:
             try:
                 self.parent.remove_child(self)
-            except:
+            except Exception:
                 #there was no ResizeHelper placed
                 pass
         if newParent==None:
@@ -55,7 +55,7 @@ class ResizeHelper(gui.Widget, gui.EventSource):
         self.refWidget = refWidget
         try:
             self.parent.append(self)
-        except:
+        except Exception:
             #the selected widget's parent can't contain a ResizeHelper
             pass
         #self.refWidget.style['position'] = 'relative'
@@ -121,7 +121,7 @@ class DragHelper(gui.Widget, gui.EventSource):
         if self.parent:
             try:
                 self.parent.remove_child(self)
-            except:
+            except Exception:
                 #there was no ResizeHelper placed
                 pass
         if newParent==None:
@@ -130,7 +130,7 @@ class DragHelper(gui.Widget, gui.EventSource):
         self.refWidget = refWidget
         try:
             self.parent.append(self)
-        except:
+        except Exception:
             #the selected widget's parent can't contain a ResizeHelper
             pass
         #self.refWidget.style['position'] = 'relative'

--- a/remi/gui.py
+++ b/remi/gui.py
@@ -1557,9 +1557,10 @@ class HEAD(Tag):
                     var message = encodeURIComponent(unescape('callback' + '/' + widgetID+'/'+functionName + '/' + paramStr));
                     this._pendingSendMessages.push(message);
                     if( this._pendingSendMessages.length < %(max_pending_messages)s ){
-                        this._ws.send(message);
-                        if(this._comTimeout==null)
-                            this._comTimeout = setTimeout(this._checkTimeout, %(messaging_timeout)s);
+                        if (this._ws !== null && this._ws.readyState == 1)
+                            this._ws.send(message);
+                            if(this._comTimeout==null)
+                                this._comTimeout = setTimeout(this._checkTimeout, %(messaging_timeout)s);
                     }else{
                         console.debug('Renewing connection, this._ws.readyState when trying to send was: ' + this._ws.readyState)
                         this._renewConnection();

--- a/remi/gui.py
+++ b/remi/gui.py
@@ -1492,7 +1492,7 @@ class HEAD(Tag):
                                 }catch(e){console.debug(e.message);};
                             }else if( received_msg[0]=='3' ){ /*ack*/
                                 self._pendingSendMessages.shift() /*remove the oldest*/
-                                if(self._comTimeout!=null)
+                                if(self._comTimeout!==null)
                                     clearTimeout(self._comTimeout);
                             }
                         };
@@ -1553,13 +1553,13 @@ class HEAD(Tag):
                 /*this uses websockets*/
                 Remi.prototype.sendCallbackParam = function (widgetID,functionName,params /*a dictionary of name:value*/){
                     var paramStr = '';
-                    if(params!=null) paramStr=this._paramPacketize(params);
+                    if(params!==null) paramStr=this._paramPacketize(params);
                     var message = encodeURIComponent(unescape('callback' + '/' + widgetID+'/'+functionName + '/' + paramStr));
                     this._pendingSendMessages.push(message);
                     if( this._pendingSendMessages.length < %(max_pending_messages)s ){
                         if (this._ws !== null && this._ws.readyState == 1)
                             this._ws.send(message);
-                            if(this._comTimeout==null)
+                            if(this._comTimeout===null)
                                 this._comTimeout = setTimeout(this._checkTimeout, %(messaging_timeout)s);
                     }else{
                         console.debug('Renewing connection, this._ws.readyState when trying to send was: ' + this._ws.readyState)

--- a/remi/gui.py
+++ b/remi/gui.py
@@ -946,31 +946,31 @@ class Widget(Tag, EventSource):
         return super(Widget, self).repr(changed_widgets)
 
     @decorate_set_on_listener("(self, emitter)")
-    @decorate_event_js("sendCallback('%(emitter_identifier)s','%(event_name)s');")
+    @decorate_event_js("remi.sendCallback('%(emitter_identifier)s','%(event_name)s');")
     def onfocus(self):
         """Called when the Widget gets focus."""
         return ()
 
     @decorate_set_on_listener("(self, emitter)")
-    @decorate_event_js("sendCallback('%(emitter_identifier)s','%(event_name)s');")
+    @decorate_event_js("remi.sendCallback('%(emitter_identifier)s','%(event_name)s');")
     def onblur(self):
         """Called when the Widget loses focus"""
         return ()
 
     @decorate_set_on_listener("(self, emitter)")
-    @decorate_event_js("sendCallback('%(emitter_identifier)s','%(event_name)s');")
+    @decorate_event_js("remi.sendCallback('%(emitter_identifier)s','%(event_name)s');")
     def onclick(self):
         """Called when the Widget gets clicked by the user with the left mouse button."""
         return ()
 
     @decorate_set_on_listener("(self, emitter)")
-    @decorate_event_js("sendCallback('%(emitter_identifier)s','%(event_name)s');")
+    @decorate_event_js("remi.sendCallback('%(emitter_identifier)s','%(event_name)s');")
     def ondblclick(self):
         """Called when the Widget gets double clicked by the user with the left mouse button."""
         return ()
 
     @decorate_set_on_listener("(self, emitter)")
-    @decorate_event_js("sendCallback('%(emitter_identifier)s','%(event_name)s');")
+    @decorate_event_js("remi.sendCallback('%(emitter_identifier)s','%(event_name)s');")
     def oncontextmenu(self):
         """Called when the Widget gets clicked by the user with the right mouse button.
         """
@@ -981,7 +981,7 @@ class Widget(Tag, EventSource):
             "var boundingBox = this.getBoundingClientRect();" \
             "params['x']=event.clientX-boundingBox.left;" \
             "params['y']=event.clientY-boundingBox.top;" \
-            "sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);")
+            "remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);")
     def onmousedown(self, x, y):
         """Called when the user presses left or right mouse button over a Widget.
 
@@ -996,7 +996,7 @@ class Widget(Tag, EventSource):
             "var boundingBox = this.getBoundingClientRect();" \
             "params['x']=event.clientX-boundingBox.left;" \
             "params['y']=event.clientY-boundingBox.top;" \
-            "sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);")
+            "remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);")
     def onmouseup(self, x, y):
         """Called when the user releases left or right mouse button over a Widget.
 
@@ -1007,7 +1007,7 @@ class Widget(Tag, EventSource):
         return (x, y)
 
     @decorate_set_on_listener("(self, emitter)")
-    @decorate_event_js("sendCallback('%(emitter_identifier)s','%(event_name)s');")
+    @decorate_event_js("remi.sendCallback('%(emitter_identifier)s','%(event_name)s');")
     def onmouseout(self):
         """Called when the mouse cursor moves outside a Widget.
 
@@ -1017,7 +1017,7 @@ class Widget(Tag, EventSource):
         return ()
 
     @decorate_set_on_listener("(self, emitter)")
-    @decorate_event_js("sendCallback('%(emitter_identifier)s','%(event_name)s');")
+    @decorate_event_js("remi.sendCallback('%(emitter_identifier)s','%(event_name)s');")
     def onmouseover(self):
         """Called when the mouse cursor moves onto a Widget.
 
@@ -1026,7 +1026,7 @@ class Widget(Tag, EventSource):
         return ()
 
     @decorate_set_on_listener("(self, emitter)")
-    @decorate_event_js("sendCallback('%(emitter_identifier)s','%(event_name)s');")
+    @decorate_event_js("remi.sendCallback('%(emitter_identifier)s','%(event_name)s');")
     def onmouseleave(self):
         """Called when the mouse cursor moves outside a Widget.
 
@@ -1043,7 +1043,7 @@ class Widget(Tag, EventSource):
             "var boundingBox = this.getBoundingClientRect();" \
             "params['x']=event.clientX-boundingBox.left;" \
             "params['y']=event.clientY-boundingBox.top;" \
-            "sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);")
+            "remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);")
     def onmousemove(self, x, y):
         """Called when the mouse cursor moves inside the Widget.
 
@@ -1058,7 +1058,7 @@ class Widget(Tag, EventSource):
             "var boundingBox = this.getBoundingClientRect();" \
             "params['x']=parseInt(event.changedTouches[0].clientX)-boundingBox.left;" \
             "params['y']=parseInt(event.changedTouches[0].clientY)-boundingBox.top;" \
-            "sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);")
+            "remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);")
     def ontouchmove(self, x, y):
         """Called continuously while a finger is dragged across the screen, over a Widget.
 
@@ -1073,7 +1073,7 @@ class Widget(Tag, EventSource):
             "var boundingBox = this.getBoundingClientRect();" \
             "params['x']=parseInt(event.changedTouches[0].clientX)-boundingBox.left;" \
             "params['y']=parseInt(event.changedTouches[0].clientY)-boundingBox.top;" \
-            "sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);")
+            "remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);")
     def ontouchstart(self, x, y):
         """Called when a finger touches the widget.
 
@@ -1088,7 +1088,7 @@ class Widget(Tag, EventSource):
             "var boundingBox = this.getBoundingClientRect();" \
             "params['x']=parseInt(event.changedTouches[0].clientX)-boundingBox.left;" \
             "params['y']=parseInt(event.changedTouches[0].clientY)-boundingBox.top;" \
-            "sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);")
+            "remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);")
     def ontouchend(self, x, y):
         """Called when a finger is released from the widget.
 
@@ -1103,7 +1103,7 @@ class Widget(Tag, EventSource):
             "var boundingBox = this.getBoundingClientRect();" \
             "params['x']=parseInt(event.changedTouches[0].clientX)-boundingBox.left;" \
             "params['y']=parseInt(event.changedTouches[0].clientY)-boundingBox.top;" \
-            "sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);")
+            "remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);")
     def ontouchenter(self, x, y):
         """Called when a finger touches from outside to inside the widget.
 
@@ -1114,14 +1114,14 @@ class Widget(Tag, EventSource):
         return (x, y)
 
     @decorate_set_on_listener("(self, emitter)")
-    @decorate_event_js("sendCallback('%(emitter_identifier)s','%(event_name)s');")
+    @decorate_event_js("remi.sendCallback('%(emitter_identifier)s','%(event_name)s');")
     def ontouchleave(self):
         """Called when a finger touches from inside to outside the widget.
         """
         return ()
 
     @decorate_set_on_listener("(self, emitter)")
-    @decorate_event_js("sendCallback('%(emitter_identifier)s','%(event_name)s');")
+    @decorate_event_js("remi.sendCallback('%(emitter_identifier)s','%(event_name)s');")
     def ontouchcancel(self):
         """Called when a touch point has been disrupted in an implementation-specific manner
         (for example, too many touch points are created).
@@ -1134,7 +1134,7 @@ class Widget(Tag, EventSource):
             params['ctrl']=event.ctrlKey;
             params['shift']=event.shiftKey;
             params['alt']=event.altKey;
-            sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);""")
+            remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);""")
     def onkeyup(self, key, keycode, ctrl, shift, alt):
         """Called when user types and releases a key.
         The widget should be able to receive the focus in order to emit the event.
@@ -1152,7 +1152,7 @@ class Widget(Tag, EventSource):
             params['ctrl']=event.ctrlKey;
             params['shift']=event.shiftKey;
             params['alt']=event.altKey;
-            sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);""")
+            remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);""")
     def onkeydown(self, key, keycode, ctrl, shift, alt):
         """Called when user types and releases a key.
         The widget should be able to receive the focus in order to emit the event.
@@ -1372,15 +1372,20 @@ class HEAD(Tag):
         self.add_child('internal_js',
                 """
                 <script>
+                'use strict';
+
+                var Remi = function() {
+                this._pendingSendMessages = [];
+                this._ws = null;
+                this._comTimeout = null;
+                this._failedConnections = 0;
+                this._openSocket();
+                };
+
                 // from http://stackoverflow.com/questions/5515869/string-length-in-bytes-in-javascript
                 // using UTF8 strings I noticed that the javascript .length of a string returned less
                 // characters than they actually were
-                var pendingSendMessages = [];
-                var ws = null;
-                var comTimeout = null;
-                var failedConnections = 0;
-
-                function byteLength(str) {
+                Remi.prototype._byteLength = function(str) {
                     // returns the byte length of an utf8 string
                     var s = str.length;
                     for (var i=str.length-1; i>=0; i--) {
@@ -1390,210 +1395,207 @@ class HEAD(Tag):
                         if (code >= 0xDC00 && code <= 0xDFFF) i--; //trail surrogate
                     }
                     return s;
-                }
+                };
 
-                var paramPacketize = function (ps){
+                Remi.prototype._paramPacketize = function (ps){
                     var ret = '';
                     for (var pkey in ps) {
                         if( ret.length>0 )ret = ret + '|';
                         var pstring = pkey+'='+ps[pkey];
-                        var pstring_length = byteLength(pstring);
+                        var pstring_length = this._byteLength(pstring);
                         pstring = pstring_length+'|'+pstring;
                         ret = ret + pstring;
                     }
                     return ret;
                 };
 
-                function openSocket(){
-                    ws_wss = "ws";
+                Remi.prototype._openSocket = function(){
+                    var ws_wss = "ws";
                     try{
                         ws_wss = document.location.protocol.startsWith('https')?'wss':'ws';
                     }catch(ex){}
 
+                    var self = this;
                     try{
-                        ws = new WebSocket(ws_wss + '://%(host)s/');
+                        this._ws = new WebSocket(ws_wss + '://%(host)s/');
                         console.debug('opening websocket');
-                        ws.onopen = websocketOnOpen;
-                        ws.onmessage = websocketOnMessage;
-                        ws.onclose = websocketOnClose;
-                        ws.onerror = websocketOnError;
-                    }catch(ex){ws=false;alert('websocketnot supported or server unreachable');}
+
+                        this._ws.onopen = function(evt){
+                            if(self._ws.readyState == 1){
+                                self._ws.send('connected');
+
+                                try {
+                                    document.getElementById("loading").style.display = 'none';
+                                } catch(err) {
+                                    console.log('Error hiding loading overlay ' + err.message);
+                                }
+
+                                self._failedConnections = 0;
+
+                                while(self._pendingSendMessages.length>0){
+                                    self._ws.send(self._pendingSendMessages.shift()); /*without checking ack*/
+                                }
+                            }
+                            else{
+                                console.debug('onopen fired but the socket readyState was not 1');
+                            }
+                        };
+
+                        this._ws.onmessage = function(evt){
+                            var received_msg = evt.data;
+
+                            if( received_msg[0]=='0' ){ /*show_window*/
+                                var index = received_msg.indexOf(',')+1;
+                                /*var idRootNodeWidget = received_msg.substr(0,index-1);*/
+                                var content = received_msg.substr(index,received_msg.length-index);
+
+                                document.body.innerHTML = decodeURIComponent(content);
+                            }else if( received_msg[0]=='1' ){ /*update_widget*/
+                                var focusedElement=-1;
+                                var caretStart=-1;
+                                var caretEnd=-1;
+                                if (document.activeElement)
+                                {
+                                    focusedElement = document.activeElement.id;
+                                    try{
+                                        caretStart = document.activeElement.selectionStart;
+                                        caretEnd = document.activeElement.selectionEnd;
+                                    }catch(e){}
+                                }
+                                var index = received_msg.indexOf(',')+1;
+                                var idElem = received_msg.substr(1,index-2);
+                                var content = received_msg.substr(index,received_msg.length-index);
+
+                                var elem = document.getElementById(idElem);
+                                try{
+                                    elem.insertAdjacentHTML('afterend',decodeURIComponent(content));
+                                    elem.parentElement.removeChild(elem);
+                                }catch(e){
+                                    /*Microsoft EDGE doesn't support insertAdjacentHTML for SVGElement*/
+                                    var ns = document.createElementNS("http://www.w3.org/2000/svg",'tmp');
+                                    ns.innerHTML = decodeURIComponent(content);
+                                    elem.parentElement.replaceChild(ns.firstChild, elem);
+                                }
+
+                                var elemToFocus = document.getElementById(focusedElement);
+                                if( elemToFocus != null ){
+                                    elemToFocus.focus();
+                                    try{
+                                        elemToFocus = document.getElementById(focusedElement);
+                                        if(caretStart>-1 && caretEnd>-1) elemToFocus.setSelectionRange(caretStart, caretEnd);
+                                    }catch(e){}
+                                }
+                            }else if( received_msg[0]=='2' ){ /*javascript*/
+                                var content = received_msg.substr(1,received_msg.length-1);
+                                try{
+                                    eval(content);
+                                }catch(e){console.debug(e.message);};
+                            }else if( received_msg[0]=='3' ){ /*ack*/
+                                self._pendingSendMessages.shift() /*remove the oldest*/
+                                if(self._comTimeout!=null)
+                                    clearTimeout(self._comTimeout);
+                            }
+                        };
+
+                        this._ws.onclose = function(evt){
+                            /* websocket is closed. */
+                            console.debug('Connection is closed... event code: ' + evt.code + ', reason: ' + evt.reason);
+                            // Some explanation on this error: http://stackoverflow.com/questions/19304157/getting-the-reason-why-websockets-closed
+                            // In practice, on a unstable network (wifi with a lot of traffic for example) this error appears
+                            // Got it with Chrome saying:
+                            // WebSocket connection to 'ws://x.x.x.x:y/' failed: Could not decode a text frame as UTF-8.
+                            // WebSocket connection to 'ws://x.x.x.x:y/' failed: Invalid frame header
+
+                            try {
+                                document.getElementById("loading").style.display = '';
+                            } catch(err) {
+                                console.log('Error hiding loading overlay ' + err.message);
+                            }
+
+                            self._failedConnections += 1;
+
+                            console.debug('failed connections=' + self._failedConnections + ' queued messages=' + self._pendingSendMessages.length);
+
+                            if(self._failedConnections > 3) {
+
+                                // check if the server has been restarted - which would give it a new websocket address,
+                                // new state, and require a reload
+                                console.debug('Checking if GUI still up ' + location.href);
+
+                                var http = new XMLHttpRequest();
+                                http.open('HEAD', location.href);
+                                http.onreadystatechange = function() {
+                                    if (http.status == 200) {
+                                        // server is up but has a new websocket address, reload
+                                        location.reload();
+                                    }
+                                };
+                                http.send();
+
+                                self._failedConnections = 0;
+                            }
+
+                            if(evt.code == 1006){
+                                self._renewConnection();
+                            }
+                        };
+
+                        this._ws.onerror = function(evt){
+                            /* websocket is closed. */
+                            /* alert('Websocket error...');*/
+                            console.debug('Websocket error... event code: ' + evt.code + ', reason: ' + evt.reason);
+                        };
+
+                    }catch(ex){this._ws=false;alert('websocketnot supported or server unreachable');}
                 }
-                openSocket();
 
-                function websocketOnMessage (evt){
-                    var received_msg = evt.data;
-
-                    if( received_msg[0]=='0' ){ /*show_window*/
-                        var index = received_msg.indexOf(',')+1;
-                        /*var idRootNodeWidget = received_msg.substr(0,index-1);*/
-                        var content = received_msg.substr(index,received_msg.length-index);
-
-                        document.body.innerHTML = decodeURIComponent(content);
-                    }else if( received_msg[0]=='1' ){ /*update_widget*/
-                        var focusedElement=-1;
-                        var caretStart=-1;
-                        var caretEnd=-1;
-                        if (document.activeElement)
-                        {
-                            focusedElement = document.activeElement.id;
-                            try{
-                                caretStart = document.activeElement.selectionStart;
-                                caretEnd = document.activeElement.selectionEnd;
-                            }catch(e){}
-                        }
-                        var index = received_msg.indexOf(',')+1;
-                        var idElem = received_msg.substr(1,index-2);
-                        var content = received_msg.substr(index,received_msg.length-index);
-
-                        var elem = document.getElementById(idElem);
-                        try{
-                            elem.insertAdjacentHTML('afterend',decodeURIComponent(content));
-                            elem.parentElement.removeChild(elem);
-                        }catch(e){
-                            /*Microsoft EDGE doesn't support insertAdjacentHTML for SVGElement*/
-                            var ns = document.createElementNS("http://www.w3.org/2000/svg",'tmp');
-                            ns.innerHTML = decodeURIComponent(content);
-                            elem.parentElement.replaceChild(ns.firstChild, elem);
-                        }
-
-                        var elemToFocus = document.getElementById(focusedElement);
-                        if( elemToFocus != null ){
-                            elemToFocus.focus();
-                            try{
-                                elemToFocus = document.getElementById(focusedElement);
-                                if(caretStart>-1 && caretEnd>-1) elemToFocus.setSelectionRange(caretStart, caretEnd);
-                            }catch(e){}
-                        }
-                    }else if( received_msg[0]=='2' ){ /*javascript*/
-                        var content = received_msg.substr(1,received_msg.length-1);
-                        try{
-                            eval(content);
-                        }catch(e){console.debug(e.message);};
-                    }else if( received_msg[0]=='3' ){ /*ack*/
-                        pendingSendMessages.shift() /*remove the oldest*/
-                        if(comTimeout!=null)
-                            clearTimeout(comTimeout);
-                    }
-                };
 
                 /*this uses websockets*/
-                var sendCallbackParam = function (widgetID,functionName,params /*a dictionary of name:value*/){
+                Remi.prototype.sendCallbackParam = function (widgetID,functionName,params /*a dictionary of name:value*/){
                     var paramStr = '';
-                    if(params!=null) paramStr=paramPacketize(params);
+                    if(params!=null) paramStr=this._paramPacketize(params);
                     var message = encodeURIComponent(unescape('callback' + '/' + widgetID+'/'+functionName + '/' + paramStr));
-                    pendingSendMessages.push(message);
-                    if( pendingSendMessages.length < %(max_pending_messages)s ){
-                        ws.send(message);
-                        if(comTimeout==null)
-                            comTimeout = setTimeout(checkTimeout, %(messaging_timeout)s);
+                    this._pendingSendMessages.push(message);
+                    if( this._pendingSendMessages.length < %(max_pending_messages)s ){
+                        this._ws.send(message);
+                        if(this._comTimeout==null)
+                            this._comTimeout = setTimeout(this._checkTimeout, %(messaging_timeout)s);
                     }else{
-                        console.debug('Renewing connection, ws.readyState when trying to send was: ' + ws.readyState)
-                        renewConnection();
+                        console.debug('Renewing connection, this._ws.readyState when trying to send was: ' + this._ws.readyState)
+                        this._renewConnection();
                     }
                 };
 
                 /*this uses websockets*/
-                var sendCallback = function (widgetID,functionName){
-                    sendCallbackParam(widgetID,functionName,null);
+                Remi.prototype.sendCallback = function (widgetID,functionName){
+                    this.sendCallbackParam(widgetID,functionName,null);
                 };
 
-                function renewConnection(){
+                Remi.prototype._renewConnection = function(){
                     // ws.readyState:
                     //A value of 0 indicates that the connection has not yet been established.
                     //A value of 1 indicates that the connection is established and communication is possible.
                     //A value of 2 indicates that the connection is going through the closing handshake.
                     //A value of 3 indicates that the connection has been closed or could not be opened.
-                    if( ws.readyState == 1){
+                    if( this._ws.readyState == 1){
                         try{
-                            ws.close();
+                            this._ws.close();
                         }catch(err){};
                     }
-                    else if(ws.readyState == 0){
+                    else if(this._ws.readyState == 0){
                     // Don't do anything, just wait for the connection to be stablished
                     }
                     else{
-                        openSocket();
+                        this._openSocket();
                     }
                 };
 
-                function checkTimeout(){
-                    if(pendingSendMessages.length>0)
-                        renewConnection();
+                Remi.prototype._checkTimeout = function(){
+                    if(this._pendingSendMessages.length>0)
+                        this._renewConnection();
                 };
 
-                function websocketOnClose(evt){
-                    /* websocket is closed. */
-                    console.debug('Connection is closed... event code: ' + evt.code + ', reason: ' + evt.reason);
-                    // Some explanation on this error: http://stackoverflow.com/questions/19304157/getting-the-reason-why-websockets-closed
-                    // In practice, on a unstable network (wifi with a lot of traffic for example) this error appears
-                    // Got it with Chrome saying:
-                    // WebSocket connection to 'ws://x.x.x.x:y/' failed: Could not decode a text frame as UTF-8.
-                    // WebSocket connection to 'ws://x.x.x.x:y/' failed: Invalid frame header
-
-                    try {
-                        document.getElementById("loading").style.display = '';
-                    } catch(err) {
-                        console.log('Error hiding loading overlay ' + err.message);
-                    }
-
-                    failedConnections += 1;
-
-                    console.debug('failed connections=' + failedConnections + ' queued messages=' + pendingSendMessages.length);
-
-                    if(failedConnections > 3) {
-
-                        // check if the server has been restarted - which would give it a new websocket address,
-                        // new state, and require a reload
-                        console.debug('Checking if GUI still up ' + location.href);
-
-                        var http = new XMLHttpRequest();
-                        http.open('HEAD', location.href);
-                        http.onreadystatechange = function() {
-                            if (http.status == 200) {
-                                // server is up but has a new websocket address, reload
-                                location.reload();
-                            }
-                        };
-                        http.send();
-
-                        failedConnections = 0;
-                    }
-
-                    if(evt.code == 1006){
-                        renewConnection();
-                    }
-
-                };
-
-                function websocketOnError(evt){
-                    /* websocket is closed. */
-                    /* alert('Websocket error...');*/
-                    console.debug('Websocket error... event code: ' + evt.code + ', reason: ' + evt.reason);
-                };
-
-                function websocketOnOpen(evt){
-                    if(ws.readyState == 1){
-                        ws.send('connected');
-
-                        try {
-                            document.getElementById("loading").style.display = 'none';
-                        } catch(err) {
-                            console.log('Error hiding loading overlay ' + err.message);
-                        }
-
-                        failedConnections = 0;
-
-                        while(pendingSendMessages.length>0){
-                            ws.send(pendingSendMessages.shift()); /*without checking ack*/
-                        }
-                    }
-                    else{
-                        console.debug('onopen fired but the socket readyState was not 1');
-                    }
-                };
-
-                function uploadFile(widgetID, eventSuccess, eventFail, eventData, file){
+                Remi.prototype.uploadFile = function(widgetID, eventSuccess, eventFail, eventData, file){
                     var url = '/';
                     var xhr = new XMLHttpRequest();
                     var fd = new FormData();
@@ -1605,17 +1607,19 @@ class HEAD(Tag):
                         if (xhr.readyState == 4 && xhr.status == 200) {
                             /* Every thing ok, file uploaded */
                             var params={};params['filename']=file.name;
-                            sendCallbackParam(widgetID, eventSuccess,params);
+                            this.sendCallbackParam(widgetID, eventSuccess,params);
                             console.log('upload success: ' + file.name);
                         }else if(xhr.status == 400){
                             var params={};params['filename']=file.name;
-                            sendCallbackParam(widgetID,eventFail,params);
+                            this.sendCallbackParam(widgetID,eventFail,params);
                             console.log('upload failed: ' + file.name);
                         }
                     };
                     fd.append('upload_file', file);
                     xhr.send(fd);
                 };
+                window.remi = new Remi();
+
                 </script>""" % {'host':net_interface_ip,
                                 'max_pending_messages':pending_messages_queue_length,
                                 'messaging_timeout':websocket_timeout_timer_ms})
@@ -1658,7 +1662,7 @@ class BODY(Container):
         self.append(loading_container)
 
     @decorate_set_on_listener("(self, emitter)")
-    @decorate_event_js("""sendCallback('%(emitter_identifier)s','%(event_name)s');""")
+    @decorate_event_js("""remi.sendCallback('%(emitter_identifier)s','%(event_name)s');""")
     def onload(self):
         """Called when page gets loaded."""
         return ()
@@ -1668,7 +1672,8 @@ class BODY(Container):
                 params['source']=event.source;
                 params['lineno']=event.lineno;
                 params['colno']=event.colno;
-                sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);
+                debugger;
+                remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);
                 return false;
             """)
     def onerror(self, message, source, lineno, colno):
@@ -1676,12 +1681,12 @@ class BODY(Container):
         return (message, source, lineno, colno)
 
     @decorate_set_on_listener("(self, emitter)")
-    @decorate_event_js("""sendCallback('%(emitter_identifier)s','%(event_name)s');""")
+    @decorate_event_js("""remi.sendCallback('%(emitter_identifier)s','%(event_name)s');""")
     def ononline(self):
         return ()
 
     @decorate_set_on_listener("(self, emitter)")
-    @decorate_event_js("""sendCallback('%(emitter_identifier)s','%(event_name)s');""")
+    @decorate_event_js("""remi.sendCallback('%(emitter_identifier)s','%(event_name)s');""")
     def onpagehide(self):
         return ()
 
@@ -1690,7 +1695,7 @@ class BODY(Container):
             var params={};
             params['width']=window.innerWidth;
             params['height']=window.innerHeight;
-            sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);""")
+            remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);""")
     def onpageshow(self, width, height):
         return (width, height)
 
@@ -1699,7 +1704,7 @@ class BODY(Container):
             var params={};
             params['width']=window.innerWidth;
             params['height']=window.innerHeight;
-            sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);""")
+            remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);""")
     def onresize(self, width, height):
         return (width, height)
 
@@ -2174,13 +2179,13 @@ class TextInput(Widget, _MixinTextualWidget):
                 if(enter_pressed){
                     elem.value = elem.value.split('\\n').join('');
                     var params={};params['new_value']=elem.value;
-                    sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);
+                    remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);
                 }""" % {'emitter_identifier': str(self.identifier), 'event_name': Widget.EVENT_ONCHANGE}
         #else:
         #    self.attributes[self.EVENT_ONINPUT] = """
         #        var elem = document.getElementById('%(emitter_identifier)s');
         #        var params={};params['new_value']=elem.value;
-        #        sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);
+        #        remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);
         #        """ % {'emitter_identifier': str(self.identifier), 'event_name': Widget.EVENT_ONCHANGE}
 
         self.set_value('')
@@ -2192,7 +2197,7 @@ class TextInput(Widget, _MixinTextualWidget):
 
         self.attributes[Widget.EVENT_ONCHANGE] = \
             "var params={};params['new_value']=document.getElementById('%(emitter_identifier)s').value;" \
-            "sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);"% \
+            "remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);"% \
             {'emitter_identifier': str(self.identifier), 'event_name': Widget.EVENT_ONCHANGE}
 
     def set_value(self, text):
@@ -2230,7 +2235,7 @@ class TextInput(Widget, _MixinTextualWidget):
     @decorate_set_on_listener("(self, emitter, new_value, keycode)")
     @decorate_event_js("""var elem=document.getElementById('%(emitter_identifier)s');
             var params={};params['new_value']=elem.value;params['keycode']=(event.which||event.keyCode);
-            sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);""")
+            remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);""")
     def onkeyup(self, new_value, keycode):
         """Called when user types and releases a key into the TextInput
 
@@ -2245,7 +2250,7 @@ class TextInput(Widget, _MixinTextualWidget):
     @decorate_set_on_listener("(self, emitter, new_value, keycode)")
     @decorate_event_js("""var elem=document.getElementById('%(emitter_identifier)s');
             var params={};params['new_value']=elem.value;params['keycode']=(event.which||event.keyCode);
-            sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);""")
+            remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);""")
     def onkeydown(self, new_value, keycode):
         """Called when the user types a key into the TextInput.
 
@@ -2698,7 +2703,7 @@ class DropDown(Container):
         self.type = 'select'
         self.attributes[self.EVENT_ONCHANGE] = \
             "var params={};params['value']=document.getElementById('%(id)s').value;" \
-            "sendCallbackParam('%(id)s','%(evt)s',params);" % {'id': self.identifier,
+            "remi.sendCallbackParam('%(id)s','%(evt)s',params);" % {'id': self.identifier,
                                                                'evt': self.EVENT_ONCHANGE}
         self._selected_item = None
         self._selected_key = None
@@ -3189,7 +3194,7 @@ class Input(Widget):
         self.attributes['autocomplete'] = 'off'
         self.attributes[Widget.EVENT_ONCHANGE] = \
             "var params={};params['value']=document.getElementById('%(emitter_identifier)s').value;" \
-            "sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);"% \
+            "remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);"% \
         {'emitter_identifier':str(self.identifier), 'event_name':Widget.EVENT_ONCHANGE}
 
     def set_value(self, value):
@@ -3279,7 +3284,7 @@ class CheckBox(Input):
         self.set_value(checked)
         self.attributes[Widget.EVENT_ONCHANGE] = \
             "var params={};params['value']=document.getElementById('%(emitter_identifier)s').checked;" \
-            "sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);"% \
+            "remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);"% \
             {'emitter_identifier':str(self.identifier), 'event_name':Widget.EVENT_ONCHANGE}
 
     @decorate_set_on_listener("(self, emitter, value)")
@@ -3358,7 +3363,7 @@ class SpinBox(Input):
         self.attributes[self.EVENT_ONKEYUP] = \
             "var key = event.keyCode || event.charCode;" \
             "if(key==13){var params={};params['value']=document.getElementById('%(id)s').value;" \
-            "sendCallbackParam('%(id)s','%(evt)s',params); return true;}" \
+            "remi.sendCallbackParam('%(id)s','%(evt)s',params); return true;}" \
             "return false;" % {'id': self.identifier, 'evt': self.EVENT_ONCHANGE}
 
 
@@ -3404,7 +3409,7 @@ class Slider(Input):
         self.attributes['step'] = str(step)
         self.attributes[Widget.EVENT_ONCHANGE] = \
             "var params={};params['value']=document.getElementById('%(emitter_identifier)s').value;" \
-            "sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);"% \
+            "remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);"% \
             {'emitter_identifier':str(self.identifier), 'event_name':Widget.EVENT_ONCHANGE}
 
     @decorate_set_on_listener("(self, emitter, value)")
@@ -3520,13 +3525,13 @@ class SelectionInput(Input):
         
         self.attributes[Widget.EVENT_ONCHANGE] = \
             "var params={};params['value']=document.getElementById('%(emitter_identifier)s').value;" \
-            "sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);"% \
+            "remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);"% \
             {'emitter_identifier':str(self.identifier), 'event_name':Widget.EVENT_ONCHANGE}
 
     @decorate_set_on_listener("(self, emitter, x, y)")
     @decorate_event_js("""var params={};
             params['value']=this.value;
-            sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);""")
+            remi.sendCallbackParam('%(emitter_identifier)s','%(event_name)s',params);""")
     def oninput(self, value):
         self.disable_refresh()
         self.set_value(value)
@@ -3890,7 +3895,7 @@ class TreeItem(Container, _MixinTextualWidget):
         return self.sub_container.append(value, key=key)
 
     @decorate_set_on_listener("(self, emitter)")
-    @decorate_event_js("sendCallback('%(emitter_identifier)s','%(event_name)s');")
+    @decorate_event_js("remi.sendCallback('%(emitter_identifier)s','%(event_name)s');")
     def onclick(self):
         self.treeopen = not self.treeopen
         if self.treeopen:
@@ -3941,7 +3946,7 @@ class FileUploader(Container):
         self.attributes[self.EVENT_ONCHANGE] = \
             "var files = this.files;" \
             "for(var i=0; i<files.length; i++){" \
-            "uploadFile('%(id)s','%(evt_success)s','%(evt_failed)s','%(evt_data)s',files[i]);}" % {
+            "remi.uploadFile('%(id)s','%(evt_success)s','%(evt_failed)s','%(evt_data)s',files[i]);}" % {
                 'id': self.identifier, 'evt_success': self.EVENT_ON_SUCCESS, 'evt_failed': self.EVENT_ON_FAILED,
                 'evt_data': self.EVENT_ON_DATA}
 
@@ -4073,7 +4078,7 @@ class VideoPlayer(Widget):
             self.attributes.pop('loop', None)
 
     @decorate_set_on_listener("(self, emitter)")
-    @decorate_event_js("sendCallback('%(emitter_identifier)s','%(event_name)s');")
+    @decorate_event_js("remi.sendCallback('%(emitter_identifier)s','%(event_name)s');")
     def onended(self):
         """Called when the media has been played and reached the end."""
         return ()

--- a/remi/gui.py
+++ b/remi/gui.py
@@ -1591,7 +1591,7 @@ class HEAD(Tag):
                 };
 
                 Remi.prototype._checkTimeout = function(){
-                    if(this._pendingSendMessages.length>0)
+                    if(this._pendingSendMessages !== undefined)
                         this._renewConnection();
                 };
 

--- a/remi/res/style.css
+++ b/remi/res/style.css
@@ -7,13 +7,13 @@
     font-weight: 400;
     src: local('Roboto'), local('Roboto-Regular'), url('/res:font.woff2') format('woff2');
 }
-textarea:focus,
-input[type='checkbox']:focus,
-input[type='color']:focus,
-input[type='number']:focus,
-input[type='text']:focus,
-input[type='date']:focus,
-select:focus {
+.remi-main textarea:focus,
+.remi-main input[type='checkbox']:focus,
+.remi-main input[type='color']:focus,
+.remi-main input[type='number']:focus,
+.remi-main input[type='text']:focus,
+.remi-main input[type='date']:focus,
+.remi-main select:focus {
     border: 0px;
     outline: 0px;
     box-shadow: 0 1px 1px 0 rgba(0, 0, 0, .14);
@@ -27,25 +27,23 @@ select:focus {
     background: rgba(2, 70, 147, 0.26);
     text-shadow: none
 }
-audio,
-canvas,
-iframe,
-img,
-svg,
-video {
+.remi-main audio,
+.remi-main canvas,
+.remi-main iframe,
+.remi-main img,
+.remi-main svg,
+.remi-main video {
     vertical-align: middle
 }
-textarea {
+.remi-main textarea {
     resize: vertical
 }
-a,
-a:visited {
+.remi-main a,
+.remi-main a:visited {
     text-decoration: underline
 }
-html {
+.remi-main {
     height: 100%;
-}
-body {
     width: 100%;
     margin: 0px;
     padding: 0px;
@@ -58,21 +56,21 @@ body {
 *[hidden] {
     display: none!important
 }
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p {
+.remi-main h1,
+.remi-main h2,
+.remi-main h3,
+.remi-main h4,
+.remi-main h5,
+.remi-main h6,
+.remi-main p {
     padding: 0
 }
-h1 small,
-h2 small,
-h3 small,
-h4 small,
-h5 small,
-h6 small {
+.remi-main h1 small,
+.remi-main h2 small,
+.remi-main h3 small,
+.remi-main h4 small,
+.remi-main h5 small,
+.remi-main h6 small {
     font-family: "Roboto", "Helvetica", "Arial", sans-serif;
     font-weight: 400;
     line-height: 1.35;
@@ -80,69 +78,69 @@ h6 small {
     opacity: .54;
     font-size: .6em
 }
-h1 {
+.remi-main h1 {
     font-size: 400%;
     line-height: 1.35;
     letter-spacing: -.02em;
     margin: 24px 0
 }
-h1,
-h2 {
+.remi-main h1,
+.remi-main h2 {
     font-family: "Roboto", "Helvetica", "Arial", sans-serif;
     font-weight: 400
 }
-h2 {
+.remi-main h2 {
     font-size: 320%;
     line-height: 48px
 }
-h2,
-h3 {
+.remi-main h2,
+.remi-main h3 {
     margin: 24px 0
 }
-h3 {
+.remi-main h3 {
     font-size: 240%;
     line-height: 40px
 }
-h3,
-h4 {
+.remi-main h3,
+.remi-main h4 {
     font-family: "Roboto", "Helvetica", "Arial", sans-serif;
     font-weight: 400
 }
-h4 {
+.remi-main h4 {
     font-size: 170%;
     line-height: 32px;
     -moz-osx-font-smoothing: grayscale;
     margin: 24px 0 16px
 }
-h5 {
+.remi-main h5 {
     font-size: 140%;
     font-weight: 500;
     line-height: 1;
     letter-spacing: .02em
 }
-h5,
-h6 {
+.remi-main h5,
+.remi-main h6 {
     font-family: "Roboto", "Helvetica", "Arial", sans-serif;
     margin: 24px 0 16px
 }
-h6 {
+.remi-main h6 {
     font-size: 114%;
     letter-spacing: .04em
 }
-h6,
-p {
+.remi-main h6,
+.remi-main p {
     font-weight: 400;
     /*line-height: 24px*/
 }
-p {
+.remi-main p {
     letter-spacing: 0;
     margin: 0px
 }
-a {
+.remi-main a {
     color: rgba(2, 70, 147, 0.8);
     font-weight: 500
 }
-blockquote {
+.remi-main blockquote {
     font-family: "Roboto", "Helvetica", "Arial", sans-serif;
     position: relative;
     font-size: 170%;
@@ -151,48 +149,48 @@ blockquote {
     line-height: 1.35;
     letter-spacing: .08em
 }
-blockquote:before {
+.remi-main blockquote:before {
     position: absolute;
     left: -.5em;
     content: '�'
 }
-blockquote:after {
+.remi-main blockquote:after {
     content: '�';
     margin-left: -.05em
 }
-mark {
+.remi-main mark {
     background-color: #f4ff81
 }
-dt {
+.remi-main dt {
     font-weight: 700
 }
-address {
+.remi-main address {
     font-size: 86%;
     line-height: 1;
     font-style: normal
 }
-address,
-ul,
-ol {
+.remi-main address,
+.remi-main ul,
+.remi-main ol {
     font-weight: 400;
     letter-spacing: 0
 }
-ul,
-ol {
+.remi-main ul,
+.remi-main ol {
     line-height: 24px
 }
-.RaisedFrame {
+.remi-main .RaisedFrame {
     box-shadow: 0 4px 5px 0 rgba(0, 0, 0, .14), 0 1px 10px 0 rgba(0, 0, 0, .12), 0 2px 4px -1px rgba(0, 0, 0, .2);
     z-index: 1;
 }
-body>div {
+.remi-main body>div {
     box-shadow: 0 4px 5px 0 rgba(0, 0, 0, .14), 0 1px 10px 0 rgba(0, 0, 0, .12), 0 2px 4px -1px rgba(0, 0, 0, .2);
 }
-div {
+.remi-main div {
     background-color: white;
     z-index: 0;
 }
-.ListView {
+.remi-main .ListView {
     border: none;
     padding: 0;
     background-color: white;
@@ -200,23 +198,23 @@ div {
     overflow: auto;
     list-style: none;
 }
-option:hover {
+.remi-main option:hover {
     background: rgba(2, 70, 147, 0.26);
     outline: 1px solid red;
 }
-.ListItem:hover {
+.remi-main .ListItem:hover {
     background: rgba(4, 90, 188, 0.26);
 }
-.ListItem[selected='True'] {
+.remi-main .ListItem[selected='True'] {
     background: rgba(4, 90, 188, 0.26);
 }
-input[type='number'],
-input[type='text'],
-input[type='date'],
-input[type='color'],
-textarea,
-li,
-select {
+.remi-main input[type='number'],
+.remi-main input[type='text'],
+.remi-main input[type='date'],
+.remi-main input[type='color'],
+.remi-main textarea,
+.remi-main li,
+.remi-main select {
     border: none;
     border-bottom: 1px solid rgba(0, 0, 0, .12);
     display: block;
@@ -229,25 +227,25 @@ select {
     padding: 0;
     background-color: rgb(245, 245, 245);
 }
-textarea:disabled,
-input[type='checkbox']:disabled,
-input[type='color']:disabled,
-input[type='number']:disabled,
-input[type='text']:disabled,
-input[type='date']:disabled {
+.remi-main textarea:disabled,
+.remi-main input[type='checkbox']:disabled,
+.remi-main input[type='color']:disabled,
+.remi-main input[type='number']:disabled,
+.remi-main input[type='text']:disabled,
+.remi-main input[type='date']:disabled {
     color: rgba(0,0,0,0.3);
     cursor: default;
     border-bottom: 1px solid rgba(0,0,0,0.3);
 }
-select {
+.remi-main select {
     border-bottom: 2px solid rgba(0, 0, 0, .12);
 }
-input[type='checkbox'] {
+.remi-main input[type='checkbox'] {
     height: 100%;
     min-height: 20px;
     min-width: 20px;
 }
-button {
+.remi-main button {
     background: 0 0;
     border: none;
     border-radius: 0px;
@@ -271,12 +269,12 @@ button {
     color: rgb(255, 255, 255);
     box-shadow: 3px 3px 5px rgb(150,150,150);
 }
-button:focus {
+.remi-main button:focus {
     box-shadow: 3px 3px 5px rgb(130,130,130);
     font-weight: bold;
     outline: 1px dashed lightgray;
 }
-button:disabled {
+.remi-main button:disabled {
     background-color: #ddd;
     background: #ddd;
     border: 1px solid #ddd;
@@ -284,11 +282,11 @@ button:disabled {
     cursor: default;
     color: #9F9F9F;
 }
-button:active{
+.remi-main button:active{
     background: rgb(2, 70, 147);
     box-shadow: 0 4px 5px 0 rgba(0, 0, 0, .2), 0 1px 1px 0 rgba(0, 0, 0, .12), 0 2px 0px -1px rgba(0, 0, 0, .2);
 }
-.TextInput {
+.remi-main .TextInput {
     border: none;
     border-bottom: 1px solid rgba(0, 0, 0, .12);
     display: block;
@@ -300,34 +298,34 @@ button:active{
     text-align: left;
     color: inherit;
 }
-table {
+.remi-main table {
     border-spacing: 0;
     overflow: scroll;
     border-collapse: collapse;
     text-align: center;
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, .1);
 }
-.TableItem {
+.remi-main .TableItem {
     padding: 0px;
     border: 1px solid white;
     outline: 0px;
 }
-.TableEditableItem>.TextInput {
+.remi-main .TableEditableItem>.TextInput {
     height: 100%;
 }
-td {
+.remi-main td {
     border: 1px solid white;
     outline: 0px;
     background-color: rgb(245,245,245);
 }
-th {
+.remi-main th {
     border: 1px solid white;
     outline: 0px;
     background: rgba(19, 108, 209, .6);
     color: rgb(255, 255, 255);
     font-weight: normal;
 }
-p.DialogTitle {
+.remi-main p.DialogTitle {
     background: rgba(19, 108, 209, .6);
     border: 0px;
     margin: 0px;
@@ -336,36 +334,36 @@ p.DialogTitle {
     text-align: center;
     margin: 0px;
 }
-p.Title {
+.remi-main p.Title {
     border: 0px;
     color: inherit;
     font-weight: bold;
 }
-nav > ul.Menu {
+.remi-main nav > ul.Menu {
     background: rgb(19, 108, 209);
     border: 0px;
     color: white;
     margin: 0px;
 }
-ul.Menu {
+.remi-main ul.Menu {
     list-style-type: none;
     padding: 0;
     position: relative;
 }
-.MenuItem {
+.remi-main .MenuItem {
     cursor: default;
     text-align: center;
     position: relative;
 }
-.Menu .Menu {
+.remi-main .Menu .Menu {
     position: absolute;
 }
-.Menu .Menu .Menu {
+.remi-main .Menu .Menu .Menu {
     top: 5%;
     left: 95%;
     position: absolute;
 }
-.MenuItem .Menu {
+.remi-main .MenuItem .Menu {
     display: none;
     background-color: white;
     /*border: 1px solid #9C9B9B;*/
@@ -377,28 +375,28 @@ ul.Menu {
     top: 100%;
     z-index: 1;
 }
-.MenuBar>.Menu>.MenuItem {
+.remi-main .MenuBar>.Menu>.MenuItem {
     border-bottom: 0;
     background: rgb(19, 108, 209);
 }
-.MenuBar {
+.remi-main .MenuBar {
     border-bottom: 1px solid rgba(0, 0, 0, .26);
 }
-.Menu > .MenuItem:hover {
+.remi-main .Menu > .MenuItem:hover {
     background: rgb(2, 70, 147);
     box-shadow: 0 4px 5px 0 rgba(0, 0, 0, .14), 0 1px 10px 0 rgba(0, 0, 0, .12), 0 2px 4px -1px rgba(0, 0, 0, .2);
 }
-.MenuItem .MenuItem:hover {
+.remi-main .MenuItem .MenuItem:hover {
     background: rgba(4, 90, 188, 0.4);
 }
-.Menu::after {
+.remi-main .Menu::after {
     content: "";
     clear: both;
 }
-.MenuItem:hover > .Menu {
+.remi-main .MenuItem:hover > .Menu {
     display: block;
 }
-input.file {
+.remi-main input.file {
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
@@ -412,7 +410,7 @@ input.file {
     background: rgb(2, 70, 147);
     box-shadow: 0 4px 5px 0 rgba(0, 0, 0, .14), 0 1px 10px 0 rgba(0, 0, 0, .12), 0 2px 4px -1px rgba(0, 0, 0, .2);
 }
-input[type='range'] {
+.remi-main input[type='range'] {
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
@@ -431,37 +429,37 @@ input[type='range'] {
     cursor: pointer;
     height: 100%;
 }
-input[type='range']::-moz-focus-outer {
+.remi-main input[type='range']::-moz-focus-outer {
     border: 0
 }
-input[type='range']::-ms-tooltip {
+.remi-main input[type='range']::-ms-tooltip {
     display: none
 }
-input[type='range']::-webkit-slider-runnable-track {
+.remi-main input[type='range']::-webkit-slider-runnable-track {
     background: rgba(2, 70, 147, 0.26);
     height: 2px;
 }
-input[type='range']::-moz-range-track {
+.remi-main input[type='range']::-moz-range-track {
     background: rgba(2, 70, 147, 0.26);
     height: 2px;
     border: none;
 }
-input[type='range']::-ms-track {
+.remi-main input[type='range']::-ms-track {
     background: rgba(2, 70, 147, 0.26);
     height: 2px;
     color: transparent;
     width: 100%;
     border: none;
 }
-input[type='range']::-ms-fill-lower {
+.remi-main input[type='range']::-ms-fill-lower {
     padding: 0;
     background: linear-gradient(to right, transparent, transparent 16px, rgb(15, 113, 225), rgb(15, 113, 225))
 }
-input[type='range']::-ms-fill-upper {
+.remi-main input[type='range']::-ms-fill-upper {
     padding: 0;
     background: linear-gradient(to left, transparent, transparent 16px, rgba(0, 0, 0, .26), rgba(0, 0, 0, .26)0)
 }
-input[type='range']::-webkit-slider-thumb {
+.remi-main input[type='range']::-webkit-slider-thumb {
     -webkit-appearance: none;
     top: -5px;
     width: 12px;
@@ -474,7 +472,7 @@ input[type='range']::-webkit-slider-thumb {
     transition: transform .18s cubic-bezier(.4, 0, .2, 1), border .18s cubic-bezier(.4, 0, .2, 1), box-shadow .18s cubic-bezier(.4, 0, .2, 1), background .28s cubic-bezier(.4, 0, .2, 1);
     transition: transform .18s cubic-bezier(.4, 0, .2, 1), border .18s cubic-bezier(.4, 0, .2, 1), box-shadow .18s cubic-bezier(.4, 0, .2, 1), background .28s cubic-bezier(.4, 0, .2, 1), -webkit-transform .18s cubic-bezier(.4, 0, .2, 1)
 }
-input[type='range']::-moz-range-thumb {
+.remi-main input[type='range']::-moz-range-thumb {
     -moz-appearance: none;
     width: 12px;
     height: 12px;
@@ -484,24 +482,24 @@ input[type='range']::-moz-range-thumb {
     background: rgb(2, 70, 147);
     border: none
 }
-input[type='range']:focus:not(:active)::-webkit-slider-thumb {
+.remi-main input[type='range']:focus:not(:active)::-webkit-slider-thumb {
     box-shadow: 0 0 0 10px rgba(4, 90, 188, 0.26);
 }
-input[type='range']:focus:not(:active)::-moz-range-thumb {
+.remi-main input[type='range']:focus:not(:active)::-moz-range-thumb {
     box-shadow: 0 0 0 10px rgba(4, 90, 188, 0.26);
 }
-input[type='range']:active::-webkit-slider-thumb {
+.remi-main input[type='range']:active::-webkit-slider-thumb {
     background-image: none;
     background: rgb(2, 70, 147);
     /*-webkit-transform: scale(1.5);*/
     /*transform: scale(1.5)*/
 }
-input[type='range']:active::-moz-range-thumb {
+.remi-main input[type='range']:active::-moz-range-thumb {
     background-image: none;
     background: rgb(2, 70, 147);
     /*transform: scale(1.5)*/
 }
-input[type='range']::-ms-thumb {
+.remi-main input[type='range']::-ms-thumb {
     width: 15px;
     height: 15px;
     border: none;
@@ -511,28 +509,28 @@ input[type='range']::-ms-thumb {
     transition: transform .18s cubic-bezier(.4, 0, .2, 1), background .28s cubic-bezier(.4, 0, .2, 1);
     transition: transform .18s cubic-bezier(.4, 0, .2, 1), background .28s cubic-bezier(.4, 0, .2, 1), -webkit-transform .18s cubic-bezier(.4, 0, .2, 1)
 }
-input[type='range']:focus:not(:active)::-ms-thumb {
+.remi-main input[type='range']:focus:not(:active)::-ms-thumb {
     background: radial-gradient(circle closest-side, rgb(15, 113, 225) 0%, rgb(15, 113, 225) 37.5%, rgba(4, 90, 188, 0.26); 37.5%, rgba(4, 90, 188, 0.26);100%);
     transform: scale(1)
 }
-input[type='range']:active::-ms-thumb {
+.remi-main input[type='range']:active::-ms-thumb {
     background: rgb(2, 70, 147);
     /*transform: scale(.5625)*/
 }
-input[type='range']:disabled:focus::-webkit-slider-thumb,
-input[type='range']:disabled:active::-webkit-slider-thumb,
-input[type='range']:disabled::-webkit-slider-thumb {
+.remi-main input[type='range']:disabled:focus::-webkit-slider-thumb,
+.remi-main input[type='range']:disabled:active::-webkit-slider-thumb,
+.remi-main input[type='range']:disabled::-webkit-slider-thumb {
     -webkit-transform: scale(.667);
     /*transform: scale(.667);*/
     background: rgba(0, 0, 0, .26)
 }
-input[type='range']:disabled:focus::-moz-range-thumb,
-input[type='range']:disabled:active::-moz-range-thumb,
-input[type='range']:disabled::-moz-range-thumb {
+.remi-main input[type='range']:disabled:focus::-moz-range-thumb,
+.remi-main input[type='range']:disabled:active::-moz-range-thumb,
+.remi-main input[type='range']:disabled::-moz-range-thumb {
     /*transform: scale(.667);*/
     background: rgba(0, 0, 0, .26)
 }
-#loading {
+#remi-loading {
     position: fixed;
     left: 0;
     top: 0;
@@ -544,7 +542,7 @@ input[type='range']:disabled::-moz-range-thumb {
     background: #000;
     opacity: 0.8;
 }
-#loading-animation {
+#remi-loading-animation {
   width: 40px;
   height: 40px;
   background-color: rgb(2, 70, 147);
@@ -562,26 +560,26 @@ input[type='range']:disabled::-moz-range-thumb {
 
 @keyframes sk-rotateplane {
   0% {
-    transform: perspective(120px) rotateX(0deg) rotateY(0deg);
-    -webkit-transform: perspective(120px) rotateX(0deg) rotateY(0deg)
+    .remi-main transform: perspective(120px) rotateX(0deg) rotateY(0deg);
+    .remi-main -webkit-transform: perspective(120px) rotateX(0deg) rotateY(0deg)
   } 50% {
-    transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg);
-    -webkit-transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg)
+    .remi-main transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg);
+    .remi-main -webkit-transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg)
   } 100% {
-    transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg);
-    -webkit-transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg);
+    .remi-main transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg);
+    .remi-main -webkit-transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg);
   }
 }
 
-.TabBox{
+.remi-main .TabBox{
     box-shadow: 3px 3px 5px rgb(150,150,150);
 }
 
-.TabBox ul {
+.remi-main .TabBox ul {
     padding-left: 0;
 }
 
-.TabBox ul li {
+.remi-main .TabBox ul li {
     list-style-type: none;
     text-align: center;
     text-decoration: none;
@@ -591,83 +589,83 @@ input[type='range']:disabled::-moz-range-thumb {
     background: #e7e7e7;
 }
 
-.TabBox ul li.active {
+.remi-main .TabBox ul li.active {
     background: white;
     outline: none;
 }
 
-.clearfix:after {
+.remi-main .clearfix:after {
     content: "";
     display: table;
     clear: both;
 }
 
 @media only screen and (max-width: 320px) {
-   body {
+   .remi-main {
     font-size: 12px;
    }
-   button {
+   .remi-main button {
     padding: 0 2px;
     font-size: 12px;
    }
-   select {
+   .remi-main select {
     font-size: 12px;
    }
 }
 
 @media only screen and (max-width: 360px) {
-   body {
+   .remi-main {
     font-size: 13px;
    }
-   button {
+   .remi-main button {
     padding: 0 2px;
     font-size: 13px;
    }
-   select {
+   .remi-main select {
     font-size: 13px;
    }
 }
 
-ul.TreeView{
+.remi-main ul.TreeView{
     list-style-type: none;
     padding: 0;
     position: relative;
     display: block;
 }
-.TreeItem{
+.remi-main .TreeItem{
     background-repeat: no-repeat;
     text-indent: 18px;
     display: block;
 }
-.TreeItem[has-subtree='true'][treeopen='false']{
+.remi-main .TreeItem[has-subtree='true'][treeopen='false']{
     background-image: url('/res:plus.png');
     background-position: 0px 4px;
 }
-.TreeItem[has-subtree='true'][treeopen='true']{
+.remi-main .TreeItem[has-subtree='true'][treeopen='true']{
     background-image: url('/res:minus.png');
     background-position: 0px 4px;
     border-bottom: 0;
 }
-.TreeItem[treeopen="false"] .TreeView .TreeItem{
+.remi-main .TreeItem[treeopen="false"] .TreeView .TreeItem{
     display: none;
 }
-.TreeItem[treeopen="false"] .TreeView{
+.remi-main .TreeItem[treeopen="false"] .TreeView{
     display: none;
 }
-.TreeItem[treeopen="true"] .TreeView{
+.remi-main .TreeItem[treeopen="true"] .TreeView{
     padding-left: 18px;
 }
-.TreeItem:hover {
+.remi-main .TreeItem:hover {
     background-color: rgba(2, 70, 147, 0.26);
 }
-.TreeItem[has-subtree='true'][treeopen='true']:hover {
+.remi-main .TreeItem[has-subtree='true'][treeopen='true']:hover {
     background-color: transparent;
 }
-a {
+.remi-main a {
     outline:none;
 }
 
-.FileFolderItem {
+.remi-main .FileFolderItem {
     margin:2px;
     display:flex;
     flex-direction:row;
@@ -675,11 +673,11 @@ a {
     justify-content: flex-start;
 }
 
-.FileFolderItem .Label{
+.remi-main .FileFolderItem .Label{
     margin:0px;
 }
 
-.FileFolderItemIcon {
+.remi-main .FileFolderItemIcon {
     width:30px;
     height:30px;
 }

--- a/remi/server.py
+++ b/remi/server.py
@@ -113,7 +113,7 @@ def parse_session_cookie(cookie_to_cook):
             #print("found session id: %s"%str(tok))
             try:
                 session_value = int(tok.replace('remi_session=', ''))
-            except:
+            except Exception:
                 pass
     return session_value
 
@@ -269,7 +269,7 @@ class WebSocketsHandler(socketserver.StreamRequestHandler):
             self.finish()
             if terminate_server:
                 self.server.shutdown()
-        except:
+        except Exception:
             self._log.error("exception in WebSocketsHandler.close method", exc_info=True)
 
 
@@ -419,12 +419,12 @@ class App(BaseHTTPRequestHandler, object):
             with self.update_lock:
                 try:
                     self.idle()
-                except:
+                except Exception:
                     self._log.error("exception in App.idle method", exc_info=True)
                 if self._need_update_flag:
                     try:
                         self.do_gui_update()
-                    except:
+                    except Exception:
                         self._log.error('''exception during gui update. It is advisable to 
                             use App.update_lock using external threads.''', exc_info=True)
 
@@ -475,12 +475,12 @@ class App(BaseHTTPRequestHandler, object):
             try:
                 #self._log.debug("sending websocket spontaneous message")
                 ws.send_message(message)
-            except:
+            except Exception:
                 self._log.error("sending websocket spontaneous message", exc_info=True)
                 try:
                     self.websockets.remove(ws)
                     ws.close(terminate_server=False)
-                except:
+                except Exception:
                     self._log.error("unable to remove websocket client - already not in list", exc_info=True)
 
     def execute_javascript(self, code):
@@ -594,7 +594,7 @@ class App(BaseHTTPRequestHandler, object):
                         self._log.info('built UI (path=%s)' % path)
                         self.set_root_widget(self.main(*self.server.userdata))
                 self._process_all(path)
-            except:
+            except Exception:
                 self._log.error('error processing GET request', exc_info=True)
 
     def _get_static_file(self, filename):
@@ -844,7 +844,7 @@ class Server(object):
         while self._alive:
             try:
                 time.sleep(1)
-            except:
+            except Exception:
                 self._alive = False
         self._log.debug(' ** serve_forever() quitting')
 

--- a/remi/server.py
+++ b/remi/server.py
@@ -360,12 +360,14 @@ class App(BaseHTTPRequestHandler, object):
             head.add_child('internal_css', "<link href='/res:style.css' rel='stylesheet' />\n")
             
             body = gui.BODY()
+            body.add_class('remi-main')
             body.onload.connect(self.onload)
             body.onerror.connect(self.onerror)
             body.ononline.connect(self.ononline)
             body.onpagehide.connect(self.onpagehide)
             body.onpageshow.connect(self.onpageshow)
             body.onresize.connect(self.onresize)
+
             self.page = gui.HTML()
             self.page.add_child('head', head)
             self.page.add_child('body', body)

--- a/test/browser_test/test_append_and_remove_widget_app_gui.py
+++ b/test/browser_test/test_append_and_remove_widget_app_gui.py
@@ -22,7 +22,7 @@ class TestAppendAndRemoveWidgetApp(unittest.TestCase):
             self.options.headless = True
             self.driver = self.DriverClass(options=self.options)
             self.driver.implicitly_wait(30)
-        except:
+        except Exception:
             self.skipTest("Selenium webdriver is not installed")
         self.server = remi.Server(MyApp, start=False, address='0.0.0.0', start_browser=False, multiple_instance=True)
         self.server.start()

--- a/test/browser_test/test_helloworld_app_gui.py
+++ b/test/browser_test/test_helloworld_app_gui.py
@@ -20,7 +20,7 @@ class TestHelloWorld(unittest.TestCase):
             self.options.headless = True
             self.driver = self.DriverClass(options=self.options)
             self.driver.implicitly_wait(30)
-        except:
+        except Exception:
             self.skipTest("Selenium webdriver is not installed")
         self.server = remi.Server(MyApp, start=False, address='0.0.0.0', start_browser=False, multiple_instance=True)
         self.server.start()


### PR DESCRIPTION
Hello,
this set of changes cleans up a few minor nits and, more importantly, teaches remi.gui to be embeddable into a larger web page, by prefixing the CSS and no longer polluting the window.* namespace.
I'd like to use Remi for my DeFramed project (https://github.com/smurfix/deframed). I already taught my code to embed Remi as an IFRAME, but that approach is much too limiting. After this gets merged (and released ;-) I can change that code to run a Remi GUI object in a simple DIV.