### PR TITLE
Proposal: Prettify code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/ambv/black
+    rev: 19.10b0
+    hooks:
+      - id: black
+        args: ['--line-length', '140']
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+      - id: flake8
+        args: ['--max-line-length=140']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,9 +8,9 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
-        args: ['--line-length', '140']
+        args: ['--line-length', '127']
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.2
     hooks:
       - id: flake8
-        args: ['--max-line-length=140', '--ignore=W191,W201,W291,W293,W391,W503,W605,E101,E203,E262,E265,E266,E302,E402,E501,E711,E712,E713,E714,E721,E741,F401,F403,F405,F811,F841']
+        args: ['--max-line-length=127', '--ignore=W191,W201,W291,W293,W391,W503,W605,E101,E203,E262,E265,E266,E302,E402,E501,E711,E712,E713,E714,E721,E741,F401,F403,F405,F811,F841']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v3.1.0
     hooks:
     - id: end-of-file-fixer
     - id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,8 @@ repos:
     hooks:
       - id: black
         args: ['--line-length', '140']
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.2
     hooks:
       - id: flake8
-        args: ['--max-line-length=140']
+        args: ['--max-line-length=140', '--ignore=W191,W201,W291,W293,W391,W503,W605,E101,E203,E262,E265,E266,E302,E402,E501,E711,E712,E713,E714,E721,E741,F401,F403,F405,F811,F841']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
   - repo: https://github.com/ambv/black
     rev: 19.10b0
     hooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,23 @@
 language: python
 cache: pip
-python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
-  - "3.7"
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
+    - python: 3.7
+      env: TOXENV=precommit
+    - python: 3.7
+      env: TOXENV=flake8
+  allow_failures:
+    env: TOXENV=precommit
 addons:
   chrome: stable
   firefox: latest
@@ -12,22 +25,9 @@ env:
   global:
     - MOZ_HEADLESS=1
 install:
-  # install dependencies from setup.py (there are none for remi)
-  - pip install -e .
-  # install optional packages (for linting, coverage, browser control)
-  # and dependencies of example apps being tested
-  - pip install flake8 coverage matplotlib Pillow selenium
+  - pip install tox
   # install specific webdrivers for selenium
   - ./test/install_webdrivers
   - export PATH="$HOME/.local/bin:$PATH"
-before_script:
-  # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
-  # this "coverage" command is equivalent to running `python test/`
-  - coverage run test/
-after_script:
-  - coverage report --include="examples/*,test/*"
-  - coverage report --include="remi/*,editor/*"
+  - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,40 @@
+[tox]
+project = remi
+# this should match the travis env list
+envlist = py27,py35,py36,py37,precommit,flake8
+
+##
+# Default tests (unit tests)
+##
+[testenv]
+deps =
+    coverage
+    matplotlib
+    Pillow
+    selenium
+whitelist_externals =
+    chromedriver
+commands =
+    python -m coverage erase
+    python -m coverage run test/
+    python -m coverage report --include="examples/*,test/*"
+    python -m coverage report --include="{toxinidir}/*remi/*,*editor/*"
+
+##
+# Syntax tests
+##
+[testenv:precommit]
+description = Run flake8, black and friends
+deps =
+    pre-commit
+commands =
+    pre-commit install -f --install-hooks
+    pre-commit run --all-files
+
+[testenv:flake8]
+description = Run essential flake8 test
+deps =
+    flake8
+commands =
+    flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics


### PR DESCRIPTION
I have a proposal to make the code closer to PEP-8 standard. There are quite good tools these days to help you along, I typically set up [pre-commit](https://pre-commit.com/) with [black](https://github.com/ambv/black) and [flake8](https://gitlab.com/pycqa/flake8). This can then easily be added in e.g. Travis so that any merge request is automatically checked after..

This merge commit already contains a proposed first config for the pre-commit, as well as automatic code cleaning from the black tool. There are numerous proposals from flake8 as well (see the ignore-list in the config file), however those edits are more manual to fix. Hence I thought I'd ask if you think this makes sense before I start on the endeavour of going through them..