### PR TITLE
Suggestion to pick up version from the git tag

### DIFF
--- a/remi/__init__.py
+++ b/remi/__init__.py
@@ -1,6 +1,40 @@
-from .gui import Widget, Button, TextInput, \
-                 SpinBox, Label, GenericDialog, InputDialog, ListView, ListItem, DropDown, DropDownItem, \
-                 Image, Table, TableRow, TableItem, TableTitle, Input, Slider, ColorPicker, Date, GenericObject, \
-                 FileFolderNavigator, FileFolderItem, FileSelectionDialog, Menu, MenuItem, FileUploader, FileDownloader, VideoPlayer
+from .gui import (
+    Widget,
+    Button,
+    TextInput,
+    SpinBox,
+    Label,
+    GenericDialog,
+    InputDialog,
+    ListView,
+    ListItem,
+    DropDown,
+    DropDownItem,
+    Image,
+    Table,
+    TableRow,
+    TableItem,
+    TableTitle,
+    Input,
+    Slider,
+    ColorPicker,
+    Date,
+    GenericObject,
+    FileFolderNavigator,
+    FileFolderItem,
+    FileSelectionDialog,
+    Menu,
+    MenuItem,
+    FileUploader,
+    FileDownloader,
+    VideoPlayer,
+)
 
 from .server import App, Server, start
+from pkg_resources import get_distribution, DistributionNotFound
+
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    pass

--- a/setup.py
+++ b/setup.py
@@ -6,17 +6,18 @@ from setuptools import setup
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-setup(name='remi',
-    version='2020.08.06',
-    description='Python REMote Interface library',
+setup(
+    name="remi",
+    description="Python REMote Interface library",
+    use_scm_version=True,
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url='https://github.com/dddomodossola/remi',
-    download_url='https://github.com/dddomodossola/remi/archive/master.zip',
-    keywords=['gui-library','remi','platform-independent','ui','gui'],
-    author='Davide Rosa',
-    author_email='dddomodossola@gmail.com',
-    license='Apache',
+    url="https://github.com/dddomodossola/remi",
+    download_url="https://github.com/dddomodossola/remi/archive/master.zip",
+    keywords=["gui-library", "remi", "platform-independent", "ui", "gui"],
+    author="Davide Rosa",
+    author_email="dddomodossola@gmail.com",
+    license="Apache",
     packages=setuptools.find_packages(),
     include_package_data=True,
 )


### PR DESCRIPTION
Rather than hard-coding the version number in setup.py, you may follow this approach.

Benefits:
 - You ensure that the git tag is accurate
 - version is defined only in one place (the git tag itself).
 - You get `remi.__version__` that tells you exact version (including commit hash), useful when users report bugs

Drawbacks:
 - version is not found in the sources anymore, which may be of interest for historical reasons in the long run
 - `import remi` is a bit slower now it looks like. This is to get `remi.__version__` dynamically, that  part could be excluded.

Below you see how it looks at runtime. The dev66 part means "66 commits ahead of the tag 2020.3.11". f276307 is the short hash of the exact commit.

```
% python
Python 3.8.5 (default, Sep  5 2020, 10:50:12) 
[GCC 10.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import remi
>>> remi.__version__
'2020.3.11.dev69+gf276307'
```

