### PR TITLE
docs: fix simple typo, expections -> exception

### DIFF
--- a/test/html_validator.py
+++ b/test/html_validator.py
@@ -14,5 +14,5 @@ class SimpleParser(HTMLParser):
 def assertValidHTML(text):
     h = SimpleParser()
     h.feed(text) 
-    # throws expections if invalid.
+    # throws exception if invalid.
     return True


### PR DESCRIPTION
There is a small typo in test/html_validator.py.

Should read `exception` rather than `expections`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md