### PR TITLE
Doc: let remi package be discoverable by Sphinx

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,7 +20,7 @@ import shlex
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
Previously building the documentation using the makefile rose warnings: it was not able to import `remi` package. The problem was that the repository root folder was not in `sys.path`, thus it was not considered when `remi.rst` tried to import `remi`.

Now all modules are correctly imported and Sphinx documentation is correctly built and populated with docstrings.

Address Issue #429 .