### PR TITLE
fix TabBox title size calculation

### DIFF
--- a/remi/gui.py
+++ b/remi/gui.py
@@ -2101,7 +2101,7 @@ class TabBox(Container):
     @decorate_set_on_listener("(self, emitter, key)")
     @decorate_event
     def on_tab_selection(self, emitter, key):
-        print(str(key))
+        #print(str(key))
         for k in self.children.keys():
             w = self.children[k]
             if w is self.container_tab_titles:

--- a/remi/gui.py
+++ b/remi/gui.py
@@ -2066,9 +2066,15 @@ class TabBox(Container):
         self.tab_keys_ordered_list = []
 
     def resize_tab_titles(self):
-        tab_w = 100.0 / len(self.container_tab_titles.children.values())
+        nch=len(self.container_tab_titles.children.values())
+        # the rounding errors of "%.1f" add upt to more than 100.0%  (e.g. at 7 tabs) , so be more precise here
+        tab_w = 1000.0 // nch  /10
         for l in self.container_tab_titles.children.values():
             l.set_size("%.1f%%" % tab_w, "auto")
+        # and make last tab consume the rounding rest, looks better
+        last_tab_w=100.0-tab_w*(nch-1)
+        l.set_size("%.1f%%" % last_tab_w, "auto")
+        
 
     def append(self, widget, key=''):
         """ Adds a new tab.


### PR DESCRIPTION
Hi
I used remi and made a TabBox with 7 tabs. This makes a wired display, the last tab gets into a second line of tab titles.
I found out that this is due to rounding errors when calculating the width to 0.1% 
Below is a fix to always calculate the with to be near but less 100.0%.
For Eye-Candy, the last tab will then be set slightly wider to fill up the rounding error.

And maybe you can also remove the debug print with the second hunk.

